### PR TITLE
fix: improve install script compatibility and error handling

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -94,11 +94,16 @@ trap cleanup EXIT
 build_rules() {
 	print_status "Building Claude Code commands and skills..."
 
-	if [[ -f "$PROJECT_DIR/scripts/build-rules.sh" ]]; then
-		bash "$PROJECT_DIR/scripts/build-rules.sh"
+	if [[ ! -f "$PROJECT_DIR/scripts/build-rules.sh" ]]; then
+		print_warning "build-rules.sh not found, skipping"
+		return
+	fi
+
+	if bash "$PROJECT_DIR/scripts/build-rules.sh"; then
 		print_success "Built commands and skills"
 	else
-		print_warning "build-rules.sh not found, skipping"
+		print_error "Failed to build commands and skills"
+		print_warning "You may need to run 'bash scripts/build-rules.sh' manually"
 	fi
 }
 

--- a/scripts/lib/dependencies.sh
+++ b/scripts/lib/dependencies.sh
@@ -155,9 +155,21 @@ install_cipher() {
 	fi
 
 	print_status "Installing Cipher..."
-	npm install -g @byterover/cipher
 
-	print_success "Installed Cipher"
+	if npm install -g @byterover/cipher; then
+		# Verify installation was successful
+		if command -v cipher &>/dev/null; then
+			print_success "Installed Cipher"
+		else
+			print_warning "Cipher was installed but command not found in PATH"
+			print_warning "You may need to restart your shell or add npm global bin to PATH"
+			echo "   Run: npm config get prefix"
+			echo "   Then add <prefix>/bin to your PATH"
+		fi
+	else
+		print_error "Failed to install Cipher"
+		print_warning "You can install it manually later with: npm install -g @byterover/cipher"
+	fi
 }
 
 # Install Newman (Postman CLI)


### PR DESCRIPTION
- Make build-rules.sh compatible with Bash 3.2+ (default on macOS)
  - Replace associative arrays with temp file storage
  - No longer requires Bash 4+ installation

- Fix ccp alias setup for better cross-platform compatibility
  - Replace sed -i with temp file approach for macOS/Linux compatibility
  - More reliable alias injection in shell configs

- Improve Cipher installation with better error handling
  - Add verification after npm install
  - Provide helpful PATH troubleshooting if command not found
  - Continue installation even if Cipher fails

Fixes issues reported with:
- Bash version requirements (<4 on some systems)
- ccp alias not being set properly
- Cipher installation not completing successfully