### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 ### 🛠️ Professional Development Environment for Claude Code (CC)
 
+[![Run in Smithery](https://smithery.ai/badge/skills/maxritter)](https://smithery.ai/skills?ns=maxritter&utm_source=github&utm_medium=badge)
+
+
 Start shipping systematically with Spec-Driven Development, Skills, TDD, Semantic Search, Persistent Memory, Context Management, Quality Hooks, Modular Rules System, and much more 🚀
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
## Add skill discoverability badge

Your 23 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Claude Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/maxritter)](https://smithery.ai/skills?ns=maxritter&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.