### PR TITLE
fix: respect local install mode in projects with .devcontainer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -422,7 +422,7 @@ run_installer() {
 		local_arg="--local --local-repo-dir $(pwd)"
 	fi
 
-	if ! is_in_container && [ ! -d ".devcontainer" ]; then
+	if ! is_in_container && ([ ! -d ".devcontainer" ] || [ "$USE_LOCAL_INSTALLER" = true ] || [ "$RESTART_PILOT" = true ]); then
 		uv run --python 3.12 --no-project --with rich --with certifi \
 			python -m installer install --local-system $version_arg $local_arg "$@"
 	else
@@ -498,13 +498,17 @@ if ! is_in_container; then
 	echo "  Current project folder: $(pwd)"
 	echo ""
 
-	if [ -d ".devcontainer" ]; then
+	if [ -d ".devcontainer" ] && [ "$USE_LOCAL_INSTALLER" != true ] && [ "$RESTART_PILOT" != true ]; then
 		echo "  Detected .devcontainer - using Dev Container mode."
 		echo ""
 		setup_devcontainer
 	elif [ "$RESTART_PILOT" = true ]; then
 		echo "  Updating local installation..."
 		echo ""
+	elif [ "$USE_LOCAL_INSTALLER" = true ]; then
+		echo "  Local installation selected (--local)"
+		echo ""
+		confirm_local_install
 	else
 		echo "  Choose installation method:"
 		echo ""


### PR DESCRIPTION
When running `install.sh` with `--restart-pilot` (update flow) or `--local` in a project that has a `.devcontainer` directory, the installer incorrectly entered Dev Container mode instead of proceeding with the local installation.

**The problem:**

If you have Pilot installed locally and run it from a project with a `.devcontainer` directory, the update flow (`--restart-pilot`) triggers devcontainer setup instead of updating the local installation. Same issue with `--local`.

**Three fixes:**
- Skip devcontainer detection when `--restart-pilot` is set
- Skip devcontainer detection when `--local` is set
- Pass `--local-system` to the Python installer when `--local` or `--restart-pilot` is set, even if `.devcontainer` exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined installer decision logic to better handle Dev Container and local installation modes across different system contexts
  * Added explicit user feedback and confirmation prompts when local installation is selected
  * Improved installation flow when using the local installer outside containerized environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->