### PR TITLE
feat: support CLAUDE_CONFIG_DIR env var in installer

### DIFF
--- a/installer/steps/claude_files.py
+++ b/installer/steps/claude_files.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 from pathlib import Path
 from typing import Any
@@ -45,6 +46,21 @@ SKIP_PATTERNS = (
 )
 
 SKIP_EXTENSIONS = (".png", ".jpg", ".jpeg", ".gif", ".webp")
+
+
+def get_claude_config_dir() -> Path:
+    """Resolve the Claude config directory from CLAUDE_CONFIG_DIR env var.
+
+    Returns Path(CLAUDE_CONFIG_DIR) if set, otherwise ~/.claude.
+    Raises ValueError if CLAUDE_CONFIG_DIR is set to a relative path.
+    """
+    env_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    if env_dir:
+        p = Path(env_dir)
+        if not p.is_absolute():
+            raise ValueError(f"CLAUDE_CONFIG_DIR must be an absolute path, got: {env_dir}")
+        return p
+    return Path.home() / ".claude"
 
 
 def patch_claude_paths(content: str) -> str:
@@ -207,7 +223,7 @@ class ClaudeFilesStep(BaseStep):
         Uses manifests to track which files Pilot installed. Only removes
         Pilot-managed files — user-created files in commands/ and rules/ are preserved.
         """
-        home_claude_dir = Path.home() / ".claude"
+        home_claude_dir = get_claude_config_dir()
         home_pilot_plugin_dir = home_claude_dir / "pilot"
 
         self._cleanup_legacy_standards_skills(home_pilot_plugin_dir)
@@ -349,7 +365,7 @@ class ClaudeFilesStep(BaseStep):
 
     def _get_dest_path(self, category: str, file_path: str, ctx: InstallContext) -> Path:
         """Determine destination path based on category."""
-        home_claude_dir = Path.home() / ".claude"
+        home_claude_dir = get_claude_config_dir()
         home_pilot_plugin_dir = home_claude_dir / "pilot"
 
         if category == "commands":
@@ -368,7 +384,7 @@ class ClaudeFilesStep(BaseStep):
 
     def _post_install_processing(self, ctx: InstallContext, ui: Any) -> None:
         """Run post-installation processing tasks."""
-        home_pilot_plugin_dir = Path.home() / ".claude" / "pilot"
+        home_pilot_plugin_dir = get_claude_config_dir() / "pilot"
 
         self._make_scripts_executable(home_pilot_plugin_dir)
 
@@ -388,7 +404,7 @@ class ClaudeFilesStep(BaseStep):
         Records filenames (relative to their directory) so the next update
         can selectively remove only Pilot's files, preserving user files.
         """
-        home_claude_dir = Path.home() / ".claude"
+        home_claude_dir = get_claude_config_dir()
         installed = ctx.config.get("installed_files", [])
 
         commands_dir = home_claude_dir / "commands"
@@ -454,12 +470,12 @@ class ClaudeFilesStep(BaseStep):
         user's ~/.claude.json. Preserves all existing app state (projects,
         oauthAccount, caches, etc.) — only sets/updates keys defined in the template.
         """
-        template_path = Path.home() / ".claude" / "pilot" / "claude.json"
+        template_path = get_claude_config_dir() / "pilot" / "claude.json"
         if not template_path.exists():
             return
 
         claude_json_path = Path.home() / ".claude.json"
-        baseline_path = Path.home() / ".claude" / ".pilot-claude-baseline.json"
+        baseline_path = get_claude_config_dir() / ".pilot-claude-baseline.json"
 
         try:
             source = json.loads(template_path.read_text())
@@ -498,7 +514,7 @@ class ClaudeFilesStep(BaseStep):
         but are no longer part of the current installation. User-created rules
         are never touched.
         """
-        home_claude_dir = Path.home() / ".claude"
+        home_claude_dir = get_claude_config_dir()
         global_rules_dir = home_claude_dir / "rules"
         if not global_rules_dir.exists():
             return

--- a/installer/steps/dependencies.py
+++ b/installer/steps/dependencies.py
@@ -12,6 +12,7 @@ from typing import Any
 from installer.context import InstallContext
 from installer.platform_utils import command_exists, is_linux_arm64, npm_global_cmd
 from installer.steps.base import BaseStep
+from installer.steps.claude_files import get_claude_config_dir
 
 MAX_RETRIES = 3
 RETRY_DELAY = 2
@@ -466,7 +467,7 @@ def _install_plugin_dependencies(_project_dir: Path, ui: Any = None) -> bool:
     This installs all Node.js dependencies defined in plugin/package.json,
     which includes runtime dependencies for MCP servers and hooks.
     """
-    plugin_dir = Path.home() / ".claude" / "pilot"
+    plugin_dir = get_claude_config_dir() / "pilot"
 
     if not plugin_dir.exists():
         if ui:
@@ -541,7 +542,7 @@ def _precache_npx_mcp_servers(_ui: Any) -> bool:
     before returning, avoiding the race condition of launching the actual
     server and killing it mid-install.
     """
-    mcp_config_path = Path.home() / ".claude" / "pilot" / ".mcp.json"
+    mcp_config_path = get_claude_config_dir() / "pilot" / ".mcp.json"
     if not mcp_config_path.exists():
         return True
 

--- a/installer/tests/conftest.py
+++ b/installer/tests/conftest.py
@@ -1,3 +1,15 @@
 """Pytest configuration for installer tests."""
 
 from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_claude_config_dir(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure CLAUDE_CONFIG_DIR is unset for all installer tests.
+
+    Prevents env var leaking from the host environment and silently
+    bypassing Path.home() mocks in existing tests.
+    """
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)

--- a/installer/tests/unit/steps/test_claude_files.py
+++ b/installer/tests/unit/steps/test_claude_files.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -986,3 +987,126 @@ class TestResolveRepoUrl:
         result = step._resolve_repo_url("v5.0.0")
 
         assert result == "https://github.com/maxritter/pilot-shell"
+
+
+class TestClaudeConfigDir:
+    """Tests for get_claude_config_dir() and CLAUDE_CONFIG_DIR env var support."""
+
+    def test_returns_env_var_path_when_set(self):
+        """get_claude_config_dir() returns the env var path when CLAUDE_CONFIG_DIR is set."""
+        from installer.steps.claude_files import get_claude_config_dir
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom_dir = Path(tmpdir) / "custom-claude"
+            custom_dir.mkdir()
+
+            with patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(custom_dir)}):
+                result = get_claude_config_dir()
+
+            assert result == custom_dir
+
+    def test_returns_default_when_env_var_unset(self):
+        """get_claude_config_dir() returns ~/.claude when CLAUDE_CONFIG_DIR is not set."""
+        from installer.steps.claude_files import get_claude_config_dir
+
+        env = os.environ.copy()
+        env.pop("CLAUDE_CONFIG_DIR", None)
+        with patch.dict(os.environ, env, clear=True):
+            result = get_claude_config_dir()
+
+        assert result == Path.home() / ".claude"
+
+    def test_raises_on_relative_path(self):
+        """get_claude_config_dir() raises ValueError when CLAUDE_CONFIG_DIR is a relative path."""
+        import pytest
+
+        from installer.steps.claude_files import get_claude_config_dir
+
+        with patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": "relative/path"}):
+            with pytest.raises(ValueError, match="absolute path"):
+                get_claude_config_dir()
+
+    def test_run_installs_to_custom_config_dir(self):
+        """ClaudeFilesStep.run() installs files under CLAUDE_CONFIG_DIR when set."""
+        from installer.context import InstallContext
+        from installer.steps.claude_files import ClaudeFilesStep
+        from installer.ui import Console
+
+        step = ClaudeFilesStep()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom_config_dir = Path(tmpdir) / "custom-claude"
+            custom_config_dir.mkdir()
+
+            home_dir = Path(tmpdir) / "home"
+            home_dir.mkdir()
+
+            source_pilot = Path(tmpdir) / "source" / "pilot"
+            source_pilot.mkdir(parents=True)
+            (source_pilot / "rules").mkdir()
+            (source_pilot / "rules" / "rule.md").write_text("rule content")
+
+            dest_dir = Path(tmpdir) / "dest"
+            dest_dir.mkdir()
+
+            ctx = InstallContext(
+                project_dir=dest_dir,
+                ui=Console(non_interactive=True),
+                local_mode=True,
+                local_repo_dir=Path(tmpdir) / "source",
+            )
+
+            with (
+                patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(custom_config_dir)}),
+                patch("installer.steps.claude_files.Path.home", return_value=home_dir),
+            ):
+                step.run(ctx)
+
+            # Files should be in custom config dir, NOT in home_dir/.claude
+            assert (custom_config_dir / "rules" / "rule.md").exists()
+            assert not (home_dir / ".claude" / "rules" / "rule.md").exists()
+
+    def test_merge_app_config_writes_claude_json_to_home(self):
+        """_merge_app_config writes ~/.claude.json to $HOME even with custom CLAUDE_CONFIG_DIR."""
+        from installer.context import InstallContext
+        from installer.steps.claude_files import ClaudeFilesStep
+        from installer.ui import Console
+
+        step = ClaudeFilesStep()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom_config_dir = Path(tmpdir) / "custom-claude"
+            custom_config_dir.mkdir()
+
+            home_dir = Path(tmpdir) / "home"
+            home_dir.mkdir()
+
+            source_pilot = Path(tmpdir) / "source" / "pilot"
+            source_pilot.mkdir(parents=True)
+            (source_pilot / "settings.json").write_text(json.dumps({"env": {"X": "1"}}))
+            (source_pilot / "claude.json").write_text(
+                json.dumps({"autoCompactEnabled": True, "theme": "dark"})
+            )
+
+            dest_dir = Path(tmpdir) / "dest"
+            dest_dir.mkdir()
+
+            ctx = InstallContext(
+                project_dir=dest_dir,
+                ui=Console(non_interactive=True),
+                local_mode=True,
+                local_repo_dir=Path(tmpdir) / "source",
+            )
+
+            with (
+                patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(custom_config_dir)}),
+                patch("installer.steps.claude_files.Path.home", return_value=home_dir),
+            ):
+                step.run(ctx)
+
+            # ~/.claude.json should be at home_dir, NOT at custom_config_dir
+            claude_json_path = home_dir / ".claude.json"
+            assert claude_json_path.exists()
+            patched = json.loads(claude_json_path.read_text())
+            assert patched["autoCompactEnabled"] is True
+
+            # Should NOT exist at custom config dir
+            assert not (custom_config_dir / ".claude.json").exists()

--- a/installer/tests/unit/steps/test_dependencies.py
+++ b/installer/tests/unit/steps/test_dependencies.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -330,33 +331,35 @@ class TestInstallPluginDependencies:
 
         assert callable(_install_plugin_dependencies)
 
-    @patch("installer.steps.dependencies.Path")
-    def test_install_plugin_dependencies_returns_false_if_no_plugin_dir(self, mock_path):
+    def test_install_plugin_dependencies_returns_false_if_no_plugin_dir(self):
         """_install_plugin_dependencies returns False if plugin directory doesn't exist."""
         from installer.steps.dependencies import _install_plugin_dependencies
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            mock_path.home.return_value = Path(tmpdir)
-            result = _install_plugin_dependencies(Path(tmpdir), ui=None)
+            config_dir = Path(tmpdir) / "claude-config"
+            config_dir.mkdir()
+            # No "pilot" subdirectory
+
+            with patch("installer.steps.dependencies.get_claude_config_dir", return_value=config_dir):
+                result = _install_plugin_dependencies(Path(tmpdir), ui=None)
             assert result is False
 
-    @patch("installer.steps.dependencies.Path")
-    def test_install_plugin_dependencies_returns_false_if_no_package_json(self, mock_path):
+    def test_install_plugin_dependencies_returns_false_if_no_package_json(self):
         """_install_plugin_dependencies returns False if no package.json exists."""
         from installer.steps.dependencies import _install_plugin_dependencies
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            plugin_dir = Path(tmpdir) / ".claude" / "pilot"
+            config_dir = Path(tmpdir) / "claude-config"
+            plugin_dir = config_dir / "pilot"
             plugin_dir.mkdir(parents=True)
 
-            mock_path.home.return_value = Path(tmpdir)
-            result = _install_plugin_dependencies(Path(tmpdir), ui=None)
+            with patch("installer.steps.dependencies.get_claude_config_dir", return_value=config_dir):
+                result = _install_plugin_dependencies(Path(tmpdir), ui=None)
             assert result is False
 
     @patch("installer.steps.dependencies._run_bash_with_retry")
     @patch("installer.steps.dependencies.command_exists")
-    @patch("installer.steps.dependencies.Path")
-    def test_install_plugin_dependencies_runs_bun_install(self, mock_path, mock_cmd_exists, mock_run):
+    def test_install_plugin_dependencies_runs_bun_install(self, mock_cmd_exists, mock_run):
         """_install_plugin_dependencies runs bun install when bun is available."""
         from installer.steps.dependencies import _install_plugin_dependencies
 
@@ -364,20 +367,20 @@ class TestInstallPluginDependencies:
         mock_run.return_value = True
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            plugin_dir = Path(tmpdir) / ".claude" / "pilot"
+            config_dir = Path(tmpdir) / "claude-config"
+            plugin_dir = config_dir / "pilot"
             plugin_dir.mkdir(parents=True)
             (plugin_dir / "package.json").write_text('{"name": "test"}')
 
-            mock_path.home.return_value = Path(tmpdir)
-            result = _install_plugin_dependencies(Path(tmpdir), ui=None)
+            with patch("installer.steps.dependencies.get_claude_config_dir", return_value=config_dir):
+                result = _install_plugin_dependencies(Path(tmpdir), ui=None)
 
             assert result is True
             mock_run.assert_called_with("bun install", cwd=plugin_dir)
 
     @patch("installer.steps.dependencies._run_bash_with_retry")
     @patch("installer.steps.dependencies.command_exists")
-    @patch("installer.steps.dependencies.Path")
-    def test_install_plugin_dependencies_falls_back_to_npm(self, mock_path, mock_cmd_exists, mock_run):
+    def test_install_plugin_dependencies_falls_back_to_npm(self, mock_cmd_exists, mock_run):
         """_install_plugin_dependencies falls back to npm install when bun is unavailable."""
         from installer.steps.dependencies import _install_plugin_dependencies
 
@@ -385,32 +388,33 @@ class TestInstallPluginDependencies:
         mock_run.return_value = True
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            plugin_dir = Path(tmpdir) / ".claude" / "pilot"
+            config_dir = Path(tmpdir) / "claude-config"
+            plugin_dir = config_dir / "pilot"
             plugin_dir.mkdir(parents=True)
             (plugin_dir / "package.json").write_text('{"name": "test"}')
 
-            mock_path.home.return_value = Path(tmpdir)
-            result = _install_plugin_dependencies(Path(tmpdir), ui=None)
+            with patch("installer.steps.dependencies.get_claude_config_dir", return_value=config_dir):
+                result = _install_plugin_dependencies(Path(tmpdir), ui=None)
 
         assert result is True
         npm_calls = [c for c in mock_run.call_args_list if "npm" in str(c)]
         assert len(npm_calls) > 0, "npm install should be called when bun is unavailable"
 
     @patch("installer.steps.dependencies.command_exists")
-    @patch("installer.steps.dependencies.Path")
-    def test_install_plugin_dependencies_returns_false_when_no_package_manager(self, mock_path, mock_cmd_exists):
+    def test_install_plugin_dependencies_returns_false_when_no_package_manager(self, mock_cmd_exists):
         """_install_plugin_dependencies returns False when neither bun nor npm is available."""
         from installer.steps.dependencies import _install_plugin_dependencies
 
         mock_cmd_exists.return_value = False
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            plugin_dir = Path(tmpdir) / ".claude" / "pilot"
+            config_dir = Path(tmpdir) / "claude-config"
+            plugin_dir = config_dir / "pilot"
             plugin_dir.mkdir(parents=True)
             (plugin_dir / "package.json").write_text('{"name": "test"}')
 
-            mock_path.home.return_value = Path(tmpdir)
-            result = _install_plugin_dependencies(Path(tmpdir), ui=None)
+            with patch("installer.steps.dependencies.get_claude_config_dir", return_value=config_dir):
+                result = _install_plugin_dependencies(Path(tmpdir), ui=None)
 
         assert result is False
 
@@ -728,11 +732,12 @@ class TestPrecacheNpxMcpServers:
         }
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            plugin_dir = Path(tmpdir) / ".claude" / "pilot"
+            config_dir = Path(tmpdir) / "claude-config"
+            plugin_dir = config_dir / "pilot"
             plugin_dir.mkdir(parents=True)
             (plugin_dir / ".mcp.json").write_text(json.dumps(mcp_config))
 
-            with patch.object(Path, "home", return_value=Path(tmpdir)):
+            with patch("installer.steps.dependencies.get_claude_config_dir", return_value=config_dir):
                 with patch(
                     "installer.steps.dependencies._is_npx_package_cached",
                     return_value=True,
@@ -755,11 +760,12 @@ class TestPrecacheNpxMcpServers:
         }
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            plugin_dir = Path(tmpdir) / ".claude" / "pilot"
+            config_dir = Path(tmpdir) / "claude-config"
+            plugin_dir = config_dir / "pilot"
             plugin_dir.mkdir(parents=True)
             (plugin_dir / ".mcp.json").write_text(json.dumps(mcp_config))
 
-            with patch.object(Path, "home", return_value=Path(tmpdir)):
+            with patch("installer.steps.dependencies.get_claude_config_dir", return_value=config_dir):
                 with patch(
                     "installer.steps.dependencies._is_npx_package_cached",
                     return_value=True,
@@ -782,11 +788,12 @@ class TestPrecacheNpxMcpServers:
         mock_proc.wait = MagicMock(return_value=0)
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            plugin_dir = Path(tmpdir) / ".claude" / "pilot"
+            config_dir = Path(tmpdir) / "claude-config"
+            plugin_dir = config_dir / "pilot"
             plugin_dir.mkdir(parents=True)
             (plugin_dir / ".mcp.json").write_text(json.dumps(mcp_config))
 
-            with patch.object(Path, "home", return_value=Path(tmpdir)):
+            with patch("installer.steps.dependencies.get_claude_config_dir", return_value=config_dir):
                 with patch(
                     "installer.steps.dependencies._is_npx_package_cached",
                     return_value=False,
@@ -1140,3 +1147,68 @@ class TestInstallPbtTools:
         result = install_pbt_tools()
 
         assert result is False
+
+
+class TestClaudeConfigDirDependencies:
+    """Tests for CLAUDE_CONFIG_DIR support in dependencies.py."""
+
+    @patch("installer.steps.dependencies._run_bash_with_retry")
+    @patch("installer.steps.dependencies.command_exists")
+    def test_install_plugin_dependencies_uses_custom_config_dir(self, mock_cmd_exists, mock_run):
+        """_install_plugin_dependencies uses CLAUDE_CONFIG_DIR when set."""
+        from installer.steps.dependencies import _install_plugin_dependencies
+
+        mock_cmd_exists.side_effect = lambda cmd: cmd == "bun"
+        mock_run.return_value = True
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom_config = Path(tmpdir) / "custom-claude"
+            plugin_dir = custom_config / "pilot"
+            plugin_dir.mkdir(parents=True)
+            (plugin_dir / "package.json").write_text('{"name": "test"}')
+
+            with patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(custom_config)}):
+                result = _install_plugin_dependencies(Path(tmpdir), ui=None)
+
+            assert result is True
+            mock_run.assert_called_with("bun install", cwd=plugin_dir)
+
+    def test_precache_npx_uses_custom_config_dir_no_mcp_json(self):
+        """_precache_npx_mcp_servers returns True with no .mcp.json in custom dir."""
+        from installer.steps.dependencies import _precache_npx_mcp_servers
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom_config = Path(tmpdir) / "custom-claude"
+            pilot_dir = custom_config / "pilot"
+            pilot_dir.mkdir(parents=True)
+
+            with patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(custom_config)}):
+                result = _precache_npx_mcp_servers(None)
+
+            assert result is True
+
+    def test_precache_npx_reads_mcp_json_from_custom_config_dir(self):
+        """_precache_npx_mcp_servers reads .mcp.json from CLAUDE_CONFIG_DIR/pilot/."""
+        import json
+
+        from installer.steps.dependencies import _precache_npx_mcp_servers
+
+        mcp_config = {
+            "mcpServers": {
+                "web-fetch": {"command": "npx", "args": ["-y", "fetcher-mcp"]},
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            custom_config = Path(tmpdir) / "custom-claude"
+            pilot_dir = custom_config / "pilot"
+            pilot_dir.mkdir(parents=True)
+            (pilot_dir / ".mcp.json").write_text(json.dumps(mcp_config))
+
+            with (
+                patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(custom_config)}),
+                patch("installer.steps.dependencies._is_npx_package_cached", return_value=True),
+            ):
+                result = _precache_npx_mcp_servers(None)
+
+            assert result is True


### PR DESCRIPTION
The installer currently hardcodes ~/.claude/ everywhere.
If you set CLAUDE_CONFIG_DIR to use a different config directory (e.g. separate work/personal setups), the installer ignores it and dumps everything into ~/.claude/ anyway.

The approach taken here is to read the env var on install.
Only caveat is that this will need to be run twice if there are two claude config dirs - which I'm personally fine with.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude configuration directory can now be customized using the `CLAUDE_CONFIG_DIR` environment variable. When set, the installer stores configuration in the specified directory instead of the default `~/.claude` location. Custom paths must be absolute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->