### PR TITLE
Add schema definitions and skill contracts for security automation

### DIFF
--- a/pilot/policy/facts.schema.yaml
+++ b/pilot/policy/facts.schema.yaml
@@ -1,0 +1,143 @@
+facts_schema_version: "0.1"
+
+# The internal fact model is the bridge between scanner outputs, skill outputs,
+# and the policy engine. Rules evaluate facts, not raw scanner blobs.
+# This keeps provider-specific output formats out of the policy layer.
+
+facts:
+  # Finding facts — populated from normalized finding/v1 records
+  finding.id:
+    type: string
+    description: "Unique finding identifier"
+    example: "finding-001"
+
+  finding.type:
+    type: string
+    description: "Normalized finding type"
+    enum:
+      - public_bucket
+      - open_port
+      - hardcoded_secret
+      - insecure_dependency
+      - iac_misconfiguration
+      - sast_vulnerability
+      - policy_violation
+      - exposed_pii
+      - privilege_escalation
+      - supply_chain_risk
+    source: "normalization.yaml#kind.finding_types"
+
+  finding.severity:
+    type: string
+    enum: [low, medium, high, critical]
+    source: "normalization.yaml#severity.values"
+
+  finding.confidence:
+    type: string
+    enum: [low, medium, high]
+
+  finding.path:
+    type: string
+    description: "File path where the finding was detected"
+    example: "infra/s3.tf"
+
+  finding.source.scanner_type:
+    type: string
+    enum: [secrets, deps, iac, sast, custom]
+
+  finding.source.provider:
+    type: string
+    description: "Scanner tool that produced the finding"
+    example: "checkov"
+
+  finding.source.rule_id:
+    type: string
+    example: "CKV_AWS_20"
+
+  finding.package.name:
+    type: string
+    description: "Package name (dep-analysis findings)"
+
+  finding.package.version:
+    type: string
+    description: "Installed package version"
+
+  finding.package.ecosystem:
+    type: string
+    enum: [npm, pypi, go, cargo, maven, rubygems, nuget, unknown]
+
+  finding.network.exposure:
+    type: string
+    enum: [public, internal, none, unknown]
+
+  finding.secret.kind:
+    type: string
+    enum:
+      - api_key
+      - private_key
+      - password
+      - token
+      - certificate
+      - connection_string
+      - oauth_credential
+      - cloud_credential
+      - generic_secret
+
+  finding.is_new_in_diff:
+    type: boolean
+    description: "True if the finding was introduced by the current change"
+
+  # Policy context facts — populated by the agent at runtime
+  policy.context.environment:
+    type: string
+    description: "Deployment environment"
+    example: "staging"
+
+  policy.context.fail_on:
+    type: string
+    enum: [low, medium, high, critical]
+    description: "Minimum severity that triggers a non-allow decision"
+
+  # Git facts — populated from git context
+  git.branch:
+    type: string
+    example: "main"
+
+  git.base_ref:
+    type: string
+    example: "origin/main"
+
+  git.head_ref:
+    type: string
+
+  # Session facts — populated by the session context
+  session.actor:
+    type: string
+    description: "GitHub username or CI service account"
+    example: "esteban"
+
+  session.is_ci:
+    type: boolean
+
+  # Run facts — populated by the agent
+  run.command:
+    type: string
+    enum: [scan, deploy, pr, release, run]
+    description: "The triggering action being evaluated"
+
+condition_operators:
+  - equals
+  - not_equals
+  - in
+  - not_in
+  - contains
+  - regex
+  - gt
+  - gte
+  - lt
+  - lte
+
+logical_combinators:
+  - all
+  - any
+  - none

--- a/pilot/policy/rule.schema.yaml
+++ b/pilot/policy/rule.schema.yaml
@@ -1,0 +1,169 @@
+rule_schema_version: "0.1"
+
+# Schema for individual policy rules.
+# Rules evaluate normalized facts (see facts.schema.yaml) and emit a decision.
+# Rules must not reference raw scanner output formats.
+#
+# Rules are organized into policy packs (directories).
+# The policy-eval skill loads packs and evaluates all applicable rules.
+
+schema:
+  type: object
+  required:
+    - id
+    - title
+    - severity
+    - applies_to
+    - match
+    - decision
+  properties:
+
+    id:
+      type: string
+      description: "Unique rule identifier, kebab-case"
+      pattern: "^[a-z][a-z0-9-]+$"
+      example: "no-public-storage"
+
+    title:
+      type: string
+      description: "Short human-readable rule name"
+      example: "Disallow public object storage"
+
+    description:
+      type: string
+      description: "Full description of what this rule enforces and why"
+
+    severity:
+      type: string
+      enum: [low, medium, high, critical]
+      description: "Inherent severity if this rule fires"
+
+    applies_to:
+      type: object
+      required:
+        - events
+      properties:
+        events:
+          type: array
+          items:
+            type: string
+            enum: [scan, run, deploy, pr, release]
+          description: "Which trigger events activate this rule"
+        targets:
+          type: array
+          items:
+            type: string
+            enum: [iac, secrets, deps, sast, code, ci, any]
+          description: "Which finding source types this rule applies to"
+        environments:
+          type: array
+          items:
+            type: string
+          description: "Restrict rule to these environments; empty = all"
+
+    match:
+      type: object
+      description: "Condition tree evaluated against facts"
+      oneOf:
+        - required: [all]
+          properties:
+            all:
+              type: array
+              items:
+                $ref: "#/definitions/condition"
+        - required: [any]
+          properties:
+            any:
+              type: array
+              items:
+                $ref: "#/definitions/condition"
+        - required: [none]
+          properties:
+            none:
+              type: array
+              items:
+                $ref: "#/definitions/condition"
+
+    decision:
+      type: object
+      required:
+        - effect
+      properties:
+        effect:
+          type: string
+          enum: [allow, warn, block]
+          description: "Effect if the rule matches"
+        message:
+          type: string
+          description: "Human-readable explanation shown in policy-eval output"
+
+    remediation:
+      type: object
+      properties:
+        guidance:
+          type: array
+          items:
+            type: string
+          description: "Ordered steps to resolve the violation"
+        reference:
+          type: string
+          description: "Link to internal runbook or external docs"
+
+    metadata:
+      type: object
+      properties:
+        tags:
+          type: array
+          items:
+            type: string
+        cwe:
+          type: array
+          items:
+            type: string
+        mitre_attack:
+          type: string
+
+definitions:
+  condition:
+    type: object
+    required:
+      - fact
+      - op
+      - value
+    properties:
+      fact:
+        type: string
+        description: "Fact path from facts.schema.yaml (e.g. finding.severity)"
+      op:
+        type: string
+        enum: [equals, not_equals, in, not_in, contains, regex, gt, gte, lt, lte]
+      value:
+        description: "Scalar, array, or regex string depending on op"
+
+# Example rule conforming to this schema:
+#
+# id: "no-public-storage"
+# title: "Disallow public object storage"
+# description: "Prevent public exposure of storage buckets in managed environments"
+# severity: "high"
+# applies_to:
+#   events: [scan, deploy, pr]
+#   targets: [iac]
+#   environments: [staging, prod]
+# match:
+#   all:
+#     - fact: "finding.type"
+#       op: "equals"
+#       value: "public_bucket"
+#     - fact: "policy.context.environment"
+#       op: "in"
+#       value: [staging, prod]
+# decision:
+#   effect: "block"
+#   message: "Public buckets are not allowed outside dev"
+# remediation:
+#   guidance:
+#     - "Set public_access_block = true"
+#     - "Restrict bucket policy principals"
+# metadata:
+#   tags: [storage, exposure]

--- a/pilot/policy/waiver.schema.yaml
+++ b/pilot/policy/waiver.schema.yaml
@@ -1,0 +1,119 @@
+waiver_schema_version: "0.1"
+
+# Schema for policy waivers.
+# Waivers are time-bounded, scoped exceptions to specific rules.
+# They must be attributable (approved_by), explainable (reason), and expiring.
+#
+# The policy-eval skill loads waivers from the configured waivers_file,
+# filters to non-expired, in-scope entries, and applies them before
+# determining the final decision.
+#
+# Expired waivers are NOT applied but are noted in policy-eval metadata.
+
+schema:
+  type: object
+  required:
+    - id
+    - rule_id
+    - scope
+    - reason
+    - approved_by
+    - expires_at
+  properties:
+
+    id:
+      type: string
+      description: "Unique waiver identifier"
+      pattern: "^waiver-[0-9]+$"
+      example: "waiver-001"
+
+    rule_id:
+      type: string
+      description: "The rule id being waived (must match rule.schema.yaml#id)"
+      example: "no-public-storage"
+
+    scope:
+      type: object
+      description: "Boundaries within which this waiver applies"
+      properties:
+        paths:
+          type: array
+          items:
+            type: string
+          description: "File path globs this waiver covers"
+        environments:
+          type: array
+          items:
+            type: string
+          description: "Environments this waiver is valid in; empty = all"
+        branches:
+          type: array
+          items:
+            type: string
+          description: "Git branch patterns this waiver applies to"
+        actors:
+          type: array
+          items:
+            type: string
+          description: "Specific actors (users, bots) this waiver is tied to"
+
+    reason:
+      type: string
+      description: "Justification for the exception; must be substantive"
+      minLength: 20
+
+    approved_by:
+      type: string
+      description: "Username of the person who authorized this waiver"
+      example: "esteban"
+
+    approved_at:
+      type: string
+      format: date-time
+      description: "ISO 8601 timestamp when the waiver was approved"
+
+    expires_at:
+      type: string
+      format: date-time
+      description: "ISO 8601 timestamp when the waiver expires; required"
+      example: "2026-06-30T00:00:00Z"
+
+    review_before:
+      type: string
+      format: date-time
+      description: "Optional earlier date to prompt review before expiry"
+
+    metadata:
+      type: object
+      properties:
+        ticket:
+          type: string
+          description: "Issue or ticket reference (e.g. JIRA-1234)"
+        notes:
+          type: string
+
+# Example waivers file conforming to this schema:
+#
+# waivers:
+#   - id: "waiver-001"
+#     rule_id: "no-public-storage"
+#     scope:
+#       paths: ["infra/dev/public-assets.tf"]
+#       environments: ["dev"]
+#     reason: "Temporary public asset hosting during migration to CloudFront"
+#     approved_by: "esteban"
+#     approved_at: "2026-01-15T12:00:00Z"
+#     expires_at: "2026-06-30T00:00:00Z"
+#     metadata:
+#       ticket: "INFRA-442"
+#
+#   - id: "waiver-002"
+#     rule_id: "no-open-ssh"
+#     scope:
+#       paths: ["infra/bastion.tf"]
+#       environments: ["staging"]
+#     reason: "Bastion host requires SSH access from VPN range; VPN CIDR restriction applied separately"
+#     approved_by: "security-team"
+#     approved_at: "2026-02-01T09:00:00Z"
+#     expires_at: "2026-04-01T00:00:00Z"
+#     review_before: "2026-03-15T00:00:00Z"

--- a/pilot/scanners/finding.schema.yaml
+++ b/pilot/scanners/finding.schema.yaml
@@ -1,0 +1,229 @@
+finding_schema_version: "0.1"
+schema_id: "finding/v1"
+
+# Normalized finding record.
+# Every scanner provider adapter MUST emit records conforming to this schema
+# regardless of the raw tool output format. This is what skills consume,
+# what the policy engine evaluates, and what audit records store.
+#
+# The schema_id "finding/v1" is the value of normalize_to in provider.schema.yaml.
+
+schema:
+  type: object
+  required:
+    - schema
+    - id
+    - source
+    - severity
+    - type
+    - title
+    - location
+  properties:
+
+    schema:
+      type: string
+      const: "finding/v1"
+      description: "Schema identifier; always finding/v1"
+
+    id:
+      type: string
+      description: "Unique finding id within the run; stable across identical findings"
+      example: "finding-001"
+
+    source:
+      type: object
+      required:
+        - scanner_type
+        - provider
+      properties:
+        scanner_type:
+          type: string
+          enum: [secrets, deps, iac, sast, custom]
+        provider:
+          type: string
+          description: "Tool that produced the finding"
+          example: "checkov"
+        rule_id:
+          type: string
+          description: "Provider-native rule identifier"
+          example: "CKV_AWS_20"
+        run_ref:
+          type: string
+          description: "Path or identifier of the raw scanner report"
+          example: ".pilot-sec/reports/checkov.json"
+
+    severity:
+      type: string
+      enum: [low, medium, high, critical]
+      description: "Normalized severity; see normalization.yaml#severity"
+
+    type:
+      type: string
+      description: "Normalized finding type"
+      enum:
+        - public_bucket
+        - open_port
+        - hardcoded_secret
+        - insecure_dependency
+        - iac_misconfiguration
+        - sast_vulnerability
+        - policy_violation
+        - exposed_pii
+        - privilege_escalation
+        - supply_chain_risk
+
+    title:
+      type: string
+      description: "Short description of the finding"
+
+    description:
+      type: string
+      description: "Full detail from the scanner"
+
+    location:
+      type: object
+      required:
+        - path
+      properties:
+        path:
+          type: string
+          description: "Relative file path where the finding was detected"
+        line:
+          type: integer
+        column:
+          type: integer
+        snippet:
+          type: string
+          description: "Code or config context; secrets must be redacted here"
+
+    resource:
+      type: object
+      description: "IaC or cloud resource context (iac, cloud findings)"
+      properties:
+        kind:
+          type: string
+          example: "aws_s3_bucket"
+        name:
+          type: string
+          example: "public_assets"
+        id:
+          type: string
+
+    package:
+      type: object
+      description: "Package context (dep findings)"
+      properties:
+        name:
+          type: string
+        version:
+          type: string
+        ecosystem:
+          type: string
+          enum: [npm, pypi, go, cargo, maven, rubygems, nuget, unknown]
+        fixed_version:
+          type: string
+        vuln_id:
+          type: string
+          description: "CVE, GHSA, or OSV identifier"
+
+    secret:
+      type: object
+      description: "Secret context (secrets findings)"
+      properties:
+        kind:
+          type: string
+          enum:
+            - api_key
+            - private_key
+            - password
+            - token
+            - certificate
+            - connection_string
+            - oauth_credential
+            - cloud_credential
+            - generic_secret
+        redacted_value:
+          type: string
+          description: "Partial value with center masked"
+        in_history:
+          type: boolean
+
+    network:
+      type: object
+      description: "Network context (iac, cloud findings)"
+      properties:
+        exposure:
+          type: string
+          enum: [public, internal, none, unknown]
+        port:
+          type: integer
+        protocol:
+          type: string
+
+    evidence:
+      type: object
+      properties:
+        message:
+          type: string
+        raw_ref:
+          type: string
+          description: "Pointer into the raw report, e.g. .pilot-sec/reports/checkov.json#CKV_AWS_20"
+
+    remediation:
+      type: object
+      properties:
+        guidance:
+          type: array
+          items:
+            type: string
+        reference:
+          type: string
+
+    confidence:
+      type: string
+      enum: [high, medium, low]
+
+    is_new_in_diff:
+      type: boolean
+      description: "True if this finding was introduced by the current change"
+
+    metadata:
+      type: object
+      properties:
+        cwe:
+          type: array
+          items:
+            type: string
+        mitre_attack:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+
+# Example normalized finding:
+#
+# schema: "finding/v1"
+# id: "finding-001"
+# source:
+#   scanner_type: "iac"
+#   provider: "checkov"
+#   rule_id: "CKV_AWS_20"
+#   run_ref: ".pilot-sec/reports/checkov.json"
+# severity: "high"
+# type: "public_bucket"
+# title: "S3 bucket allows public read access"
+# location:
+#   path: "infra/s3.tf"
+#   line: 42
+# resource:
+#   kind: "aws_s3_bucket"
+#   name: "public_assets"
+# evidence:
+#   message: "Public ACL detected"
+#   raw_ref: ".pilot-sec/reports/checkov.json#CKV_AWS_20"
+# remediation:
+#   guidance:
+#     - "Disable public ACL"
+# confidence: "high"
+# is_new_in_diff: true

--- a/pilot/scanners/provider.schema.yaml
+++ b/pilot/scanners/provider.schema.yaml
@@ -1,0 +1,142 @@
+provider_schema_version: "0.1"
+
+# Schema for scanner provider configuration entries.
+# Each scanner type (secrets, deps, iac, sast) has a provider block
+# that declares which tool fulfills it, how it runs, how failures are handled,
+# and what normalized schema it emits.
+#
+# Provider configs are consumed by scanner adapter code and by agents
+# that invoke scanners. Vendor-specific flags go in args or a separate
+# config_file to keep the main config readable.
+
+schema:
+  type: object
+  required:
+    - provider
+    - mode
+    - normalize_to
+  properties:
+
+    provider:
+      type: string
+      description: "Tool name; must match an installed adapter"
+      examples: [gitleaks, osv, checkov, semgrep, trufflehog, trivy, tfsec]
+
+    mode:
+      type: string
+      enum: [blocking, advisory]
+      description: |
+        blocking: findings at or above the configured threshold halt the event
+        advisory: findings are reported but do not halt
+
+    timeout_seconds:
+      type: integer
+      minimum: 10
+      maximum: 600
+      default: 120
+
+    config_file:
+      type: string
+      description: "Path to provider-specific config file (e.g. .gitleaks.toml)"
+
+    normalize_to:
+      type: string
+      const: "finding/v1"
+      description: "All providers must normalize output to finding/v1"
+
+    paths:
+      type: array
+      items:
+        type: string
+      description: "Directories or file globs to scan; overrides global scope"
+
+    lockfiles:
+      type: array
+      items:
+        type: string
+      description: "Specific lockfiles for dep scanners"
+
+    rulesets:
+      type: array
+      items:
+        type: string
+      description: "Named rulesets for SAST scanners"
+
+    args:
+      type: object
+      description: "Provider-specific flags; see per-provider docs below"
+      additionalProperties: true
+
+    on_error:
+      type: object
+      properties:
+        strategy:
+          type: string
+          enum: [fail-closed, fail-open, warn]
+          default: fail-closed
+          description: |
+            fail-closed: treat scanner failure as a blocking error
+            fail-open: skip scanner results and continue
+            warn: emit a warning but allow the event to proceed
+        message:
+          type: string
+          description: "Message emitted when error strategy is triggered"
+
+# Per-provider args documentation:
+#
+# gitleaks:
+#   redact: bool        — redact secret values in report
+#   staged: bool        — scan staged files only (pre-commit mode)
+#   baseline: string    — path to baseline report to diff against
+#
+# trufflehog:
+#   only_verified: bool — only emit verified (live) secrets
+#   json: bool          — json output (required for normalization)
+#
+# osv:
+#   include_transitive: bool  — include transitive deps
+#   ignore_file: string       — path to .osv-ignore
+#
+# snyk:
+#   severity_threshold: string — low | medium | high | critical
+#   all_projects: bool
+#
+# checkov:
+#   framework: [terraform, kubernetes, dockerfile, bicep, cloudformation]
+#   skip_check: [CKV_AWS_20, ...]  — rules to suppress (prefer waivers)
+#   external_checks_dir: string
+#
+# tfsec:
+#   exclude: [aws-s3-*]
+#   config_file: string
+#
+# semgrep:
+#   config: [auto, p/security-audit, p/secrets]
+#   exclude: [tests/, fixtures/]
+#
+# trivy:
+#   scanners: [vuln, secret, config]
+#   severity: [HIGH, CRITICAL]
+#   ignore_unfixed: bool
+
+# Registered scanner types and their expected provider capabilities:
+#
+# secrets:
+#   purpose: detect credentials, keys, and tokens in code and history
+#   recommended_providers: [gitleaks, trufflehog]
+#   output_types: [hardcoded_secret]
+#
+# deps:
+#   purpose: identify vulnerable or malicious dependencies
+#   recommended_providers: [osv, snyk, trivy]
+#   output_types: [insecure_dependency, supply_chain_risk]
+#
+# iac:
+#   purpose: detect misconfigurations in infrastructure-as-code
+#   recommended_providers: [checkov, tfsec, trivy]
+#   output_types: [iac_misconfiguration, public_bucket, open_port, privilege_escalation]
+#
+# sast:
+#   purpose: detect source code vulnerabilities
+#   recommended_providers: [semgrep, codeql]
+#   output_types: [sast_vulnerability, exposed_pii]

--- a/pilot/skills/_base/contract.yaml
+++ b/pilot/skills/_base/contract.yaml
@@ -1,0 +1,94 @@
+skill_contract_version: "0.1"
+
+# Base contract inherited by all skills.
+# Each skill MUST declare its own id, category, version, and description,
+# then specialize input_schema, output_schema, and execution constraints.
+#
+# Dependency rule: agents call skills; skills NEVER call agents.
+# This keeps the dependency graph acyclic.
+
+execution:
+  mode: "read-only"               # read-only | bounded-write
+  timeout_seconds: 120
+  max_tool_calls: 6
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist: []                  # each skill adds its own safe commands
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+      description: "What the skill must determine or produce"
+    scope:
+      type: array
+      items:
+        type: string
+      description: "Paths, patterns, or identifiers bounding the analysis"
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Files, refs, or prior skill outputs available as input"
+    constraints:
+      type: object
+      description: "Optional caller-imposed limits (e.g. severity_threshold)"
+    context:
+      type: object
+      description: "Optional ambient metadata (branch, actor, environment)"
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - findings
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      description: "Skill id that produced this output"
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+      description: "One or two sentence narrative of what was found"
+    findings:
+      type: array
+      items:
+        type: object
+      description: "Structured finding records; schema specialized per skill"
+    artifacts_used:
+      type: array
+      items:
+        type: string
+      description: "Exact paths or refs consumed during execution"
+    confidence:
+      type: string
+      enum: [high, medium, low]
+    metadata:
+      type: object
+      description: "Optional: timing, tool versions, counts"
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true
+
+normalization:
+  # All skills MUST use these shared vocabularies.
+  # Do not invent local severity or confidence labels.
+  severity_scale: [low, medium, high, critical]
+  confidence_scale: [low, medium, high]
+  decision_scale: [allow, warn, block, investigate]

--- a/pilot/skills/_base/normalization.yaml
+++ b/pilot/skills/_base/normalization.yaml
@@ -1,0 +1,58 @@
+normalization_version: "0.1"
+
+# Shared vocabulary enforced across all skills.
+# Agents consume multiple skill outputs; without this shared vocabulary
+# they would need translation glue between every skill pair.
+# These are the ONLY valid values for their respective fields.
+
+severity:
+  values: [low, medium, high, critical]
+  mapping:
+    # Common upstream scanner mappings -> canonical
+    info: low
+    note: low
+    warning: medium
+    error: high
+    blocker: critical
+    # CVSS rough bands
+    cvss_0_3: low
+    cvss_4_6: medium
+    cvss_7_8: high
+    cvss_9_10: critical
+
+confidence:
+  values: [low, medium, high]
+  guidance:
+    high: "Direct evidence; deterministic match"
+    medium: "Strong indicator; may require confirmation"
+    low: "Heuristic or indirect signal; treat as advisory"
+
+decision:
+  values: [allow, warn, block, investigate]
+  semantics:
+    allow: "No action required; proceed"
+    warn: "Flag for human review but do not halt"
+    block: "Halt the triggering event (deploy, merge, run)"
+    investigate: "Escalate; requires human triage before decision"
+
+kind:
+  # Used in changed_surfaces.kind and finding.type groupings
+  surface_kinds: [code, config, infra, ci, manifest, secret-surface]
+  finding_types:
+    - public_bucket
+    - open_port
+    - hardcoded_secret
+    - insecure_dependency
+    - iac_misconfiguration
+    - sast_vulnerability
+    - policy_violation
+    - exposed_pii
+    - privilege_escalation
+    - supply_chain_risk
+
+evidence_reference:
+  # How findings link back to raw scanner output
+  format: "<report_path>#<rule_id_or_line>"
+  example: ".pilot-sec/reports/checkov.json#CKV_AWS_20"
+
+finding_schema_ref: "scanners/finding.schema.yaml"

--- a/pilot/skills/dep-analysis/prompt.md
+++ b/pilot/skills/dep-analysis/prompt.md
@@ -1,0 +1,85 @@
+# Skill: dep-analysis
+
+## Purpose
+
+Identify vulnerable, malicious, or policy-violating dependencies from lockfiles,
+manifests, and pre-run scanner reports. Focus on changes introduced in the current
+diff when `changed_only` is true.
+
+This skill does not run package managers or network calls. It reads existing
+lockfiles and reports.
+
+## Input
+
+- `artifacts`: lockfiles (package-lock.json, poetry.lock, go.sum, Cargo.lock),
+  manifest files, or pre-run osv/snyk JSON report paths
+- `constraints.severity_threshold`: filter findings below this severity
+- `constraints.include_transitive`: whether to report transitive vulnerabilities
+- `constraints.changed_only`: if true, only report on deps that changed in the diff
+
+## Execution steps
+
+1. Locate manifest and lockfiles within scope using Glob.
+2. If pre-run reports exist in `artifacts`, read and normalize them to `finding/v1`.
+3. If only raw manifests/lockfiles are present:
+   a. Read each lockfile and extract package names + resolved versions.
+   b. Cross-reference against any advisory data in artifacts (osv JSON, snyk JSON).
+   c. If `changed_only`, run `git diff <ref>` on the lockfile and extract only added/changed lines.
+4. For each vulnerable package:
+   a. Identify vuln_id (CVE, GHSA, OSV).
+   b. Determine severity from advisory data.
+   c. Note whether it is a transitive dependency and trace `introduced_by`.
+   d. Note `is_new_in_diff` if the package was added or upgraded in the current change.
+5. Apply `severity_threshold` filter.
+6. Set aggregate `status`: success if complete, partial if some lockfiles were unreadable.
+
+## Ecosystem detection
+
+| Ecosystem | Manifest | Lockfile |
+|-----------|----------|----------|
+| npm | package.json | package-lock.json, yarn.lock, pnpm-lock.yaml |
+| pypi | pyproject.toml, requirements.txt | poetry.lock, uv.lock |
+| go | go.mod | go.sum |
+| cargo | Cargo.toml | Cargo.lock |
+| maven | pom.xml | - |
+
+## Output contract
+
+Return a JSON object conforming to `skill.yaml#output_schema`.
+
+```json
+{
+  "skill": "dep-analysis",
+  "status": "success",
+  "summary": "3 vulnerable packages; 1 new critical introduced in this PR",
+  "findings": [
+    {
+      "id": "dep-001",
+      "package_name": "lodash",
+      "installed_version": "4.17.15",
+      "fixed_version": "4.17.21",
+      "severity": "high",
+      "vuln_id": "CVE-2021-23337",
+      "title": "Prototype Pollution in lodash",
+      "is_transitive": false,
+      "is_new_in_diff": true,
+      "ecosystem": "npm",
+      "remediation": "Upgrade lodash to >= 4.17.21"
+    }
+  ],
+  "artifacts_used": ["package-lock.json"],
+  "confidence": "high",
+  "metadata": {
+    "packages_evaluated": 142,
+    "new_deps_in_diff": 3
+  }
+}
+```
+
+## Constraints
+
+- Do not run npm, pip, go, or any package manager commands.
+- Do not make network calls; use only artifacts provided.
+- If no advisory data is available to cross-reference, return `status: partial`
+  with a note that findings may be incomplete.
+- Only use Glob, Read, Grep, and the bash allowlist: `git diff`, `git show`.

--- a/pilot/skills/dep-analysis/skill.yaml
+++ b/pilot/skills/dep-analysis/skill.yaml
@@ -1,0 +1,130 @@
+skill_contract_version: "0.1"
+extends: "../_base/contract.yaml"
+
+skill:
+  id: "dep-analysis"
+  category: "analysis"
+  version: "0.1"
+  description: "Identify vulnerable, malicious, or policy-violating dependencies"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 120
+  max_tool_calls: 8
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist:
+      - git diff
+      - git show
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Lockfiles, manifest files, or osv/snyk report paths"
+    constraints:
+      type: object
+      properties:
+        severity_threshold:
+          type: string
+          enum: [low, medium, high, critical]
+        include_transitive:
+          type: boolean
+          default: true
+        changed_only:
+          type: boolean
+          description: "Only evaluate deps that changed in the diff"
+    context:
+      type: object
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - findings
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      const: "dep-analysis"
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    findings:
+      type: array
+      items:
+        type: object
+        required: [id, package_name, installed_version, severity, vuln_id, title]
+        properties:
+          id:
+            type: string
+          package_name:
+            type: string
+          installed_version:
+            type: string
+          fixed_version:
+            type: string
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+          vuln_id:
+            type: string
+            description: "CVE, GHSA, or OSV identifier"
+          title:
+            type: string
+          cwe:
+            type: array
+            items:
+              type: string
+          is_transitive:
+            type: boolean
+          introduced_by:
+            type: string
+            description: "Direct dep that pulls in this transitive dep"
+          is_new_in_diff:
+            type: boolean
+          remediation:
+            type: string
+          ecosystem:
+            type: string
+            enum: [npm, pypi, go, cargo, maven, rubygems, nuget, unknown]
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+    metadata:
+      type: object
+      properties:
+        packages_evaluated:
+          type: integer
+        new_deps_in_diff:
+          type: integer
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true

--- a/pilot/skills/diff-analysis/prompt.md
+++ b/pilot/skills/diff-analysis/prompt.md
@@ -1,0 +1,67 @@
+# Skill: diff-analysis
+
+## Purpose
+
+Extract security-relevant change signals from a git diff. Produce a structured
+surface map so downstream agents can prioritize scanner scope and threat modeling.
+
+This skill does not make policy decisions. It only classifies what changed.
+
+## Input
+
+- `objective`: what the caller wants to understand (e.g. "identify high-risk surfaces in this PR")
+- `scope`: file globs or git refs to bound the analysis
+- `artifacts`: commit refs, branch names, or diff files to analyze
+- `context.branch`, `context.base_ref`, `context.head_ref`: optional git context
+
+## Execution steps
+
+1. Run `git diff <base_ref>..<head_ref> --name-status` or read provided diff files.
+2. Classify each changed file by `kind`:
+   - `code`: source files (.py, .ts, .go, .js, .rb, etc.)
+   - `config`: application config (.env, .yaml, .json, .toml, .ini)
+   - `infra`: Terraform, CloudFormation, Helm, Kubernetes manifests
+   - `ci`: GitHub Actions, GitLab CI, Dockerfile, .github/
+   - `manifest`: package.json, pyproject.toml, go.mod, Cargo.toml, requirements.txt
+   - `secret-surface`: files likely to contain or reference secrets
+3. Assign `risk_hint` per file:
+   - `critical`: credentials, private keys, production infra changes, CI pipeline mutations
+   - `high`: manifest changes (dep additions), auth code, IAM/RBAC, network config
+   - `medium`: application config, test infra, API clients
+   - `low`: docs, comments, formatting, test fixtures
+4. Emit `findings` for specific patterns within the diff:
+   - New files added in sensitive locations (`.github/`, `infra/`, root `.env`)
+   - Removal of security controls (e.g. deleted secret scanner config)
+   - Credential-shaped strings introduced (defer detail to secret-hygiene skill)
+5. Return `changed_surfaces` sorted by `risk_hint` descending.
+
+## Output contract
+
+Return a JSON object conforming to `skill.yaml#output_schema`.
+
+```json
+{
+  "skill": "diff-analysis",
+  "status": "success",
+  "summary": "14 files changed; 3 high-risk surfaces identified (CI pipeline, infra, manifest)",
+  "changed_surfaces": [
+    {
+      "path": ".github/workflows/deploy.yml",
+      "kind": "ci",
+      "risk_hint": "critical",
+      "lines_added": 22,
+      "lines_removed": 4
+    }
+  ],
+  "findings": [],
+  "artifacts_used": ["git diff origin/main..HEAD"],
+  "confidence": "high"
+}
+```
+
+## Constraints
+
+- Do not read file contents beyond what is needed to classify kind and risk_hint.
+- Do not run scanners. Surface classification only.
+- If the diff is unavailable, return `status: partial` and explain in `metadata.error`.
+- Use only the bash allowlist: `git diff`, `git status`, `git show`, `git log`.

--- a/pilot/skills/diff-analysis/skill.yaml
+++ b/pilot/skills/diff-analysis/skill.yaml
@@ -1,0 +1,136 @@
+skill_contract_version: "0.1"
+extends: "../_base/contract.yaml"
+
+skill:
+  id: "diff-analysis"
+  category: "analysis"
+  version: "0.1"
+  description: "Extract security-relevant change signals from a git diff"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 120
+  max_tool_calls: 6
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist:
+      - git diff
+      - git status
+      - git show
+      - git log
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+      description: "File globs or git refs bounding the diff surface"
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Specific commit refs, branch names, or diff files"
+    constraints:
+      type: object
+      properties:
+        severity_threshold:
+          type: string
+          enum: [low, medium, high, critical]
+        changed_only:
+          type: boolean
+    context:
+      type: object
+      properties:
+        branch:
+          type: string
+        base_ref:
+          type: string
+        head_ref:
+          type: string
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - changed_surfaces
+    - findings
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      const: "diff-analysis"
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    changed_surfaces:
+      type: array
+      items:
+        type: object
+        required: [path, kind, risk_hint]
+        properties:
+          path:
+            type: string
+          kind:
+            type: string
+            enum: [code, config, infra, ci, manifest, secret-surface]
+          risk_hint:
+            type: string
+            enum: [low, medium, high, critical]
+          lines_added:
+            type: integer
+          lines_removed:
+            type: integer
+    findings:
+      type: array
+      items:
+        type: object
+        required: [id, severity, title, path]
+        properties:
+          id:
+            type: string
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+          title:
+            type: string
+          path:
+            type: string
+          detail:
+            type: string
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+    metadata:
+      type: object
+      properties:
+        files_changed:
+          type: integer
+        base_ref:
+          type: string
+        head_ref:
+          type: string
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true

--- a/pilot/skills/evidence-pack/prompt.md
+++ b/pilot/skills/evidence-pack/prompt.md
@@ -1,0 +1,76 @@
+# Skill: evidence-pack
+
+## Purpose
+
+Collect and normalize evidence from scanner reports, prior skill outputs, and
+CI artifacts into a structured evidence record. Used as the input to release
+gates and audit logs.
+
+This skill collects; it does not evaluate. Policy decisions belong to policy-eval.
+
+## Input
+
+- `artifacts`: paths to scanner reports, skill output JSON files, CI log paths, or git refs
+- `constraints.required_evidence_kinds`: list of evidence types the caller requires
+- `constraints.min_confidence`: minimum confidence level to accept an evidence item
+- `context.release_ref`: git ref being evaluated (commit sha, tag, branch)
+
+## Execution steps
+
+1. For each artifact in `artifacts`:
+   a. Determine its `kind` from file name, path pattern, or content inspection.
+   b. Read the artifact and extract: status (passed/failed/partial), confidence, summary.
+   c. Record the artifact reference exactly as found (path + optional anchor).
+2. For each `required_evidence_kinds` entry:
+   a. Check whether a matching evidence item was found.
+   b. If not found, add its kind to `missing_evidence`.
+3. Filter out evidence items below `min_confidence` if specified.
+4. Set aggregate `status`:
+   - `success`: all required kinds found, none failed
+   - `partial`: some required kinds missing, or some items are partial
+   - `failed`: critical evidence failed or majority of required kinds missing
+
+## Evidence kind patterns
+
+| kind | Typical file patterns |
+|------|-----------------------|
+| secret-scan | `*gitleaks*`, `*truffleog*`, `*secret*` |
+| dep-scan | `*osv*`, `*snyk*`, `*deps*` |
+| iac-scan | `*checkov*`, `*tfsec*`, `*iac*` |
+| sast-scan | `*semgrep*`, `*sast*`, `*sarif*` |
+| policy-decision | `*policy*`, `*policy-eval*` |
+| test-results | `*junit*`, `*pytest*`, `*coverage*` |
+| threat-model | `*threat-model*`, `*threat*` |
+
+## Output contract
+
+Return a JSON object conforming to `skill.yaml#output_schema`.
+
+```json
+{
+  "skill": "evidence-pack",
+  "status": "partial",
+  "summary": "4 of 5 required evidence kinds collected; dep-scan missing",
+  "evidence": [
+    {
+      "id": "ev-001",
+      "kind": "secret-scan",
+      "source": "gitleaks",
+      "status": "passed",
+      "confidence": "high",
+      "ref": ".pilot-sec/reports/gitleaks.json",
+      "summary": "No secrets detected in 14 changed files"
+    }
+  ],
+  "missing_evidence": ["dep-scan"],
+  "artifacts_used": [".pilot-sec/reports/"],
+  "confidence": "medium"
+}
+```
+
+## Constraints
+
+- Do not run scanners. Collect and normalize existing reports only.
+- Do not modify any files.
+- If an artifact is unreadable, record it as `status: partial` and continue.
+- Redact any secret values found in report content; reference only metadata.

--- a/pilot/skills/evidence-pack/skill.yaml
+++ b/pilot/skills/evidence-pack/skill.yaml
@@ -1,0 +1,149 @@
+skill_contract_version: "0.1"
+extends: "../_base/contract.yaml"
+
+skill:
+  id: "evidence-pack"
+  category: "collection"
+  version: "0.1"
+  description: "Collect and normalize evidence for release gates or audit records"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 180
+  max_tool_calls: 16
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist:
+      - git log
+      - git show
+      - git diff
+      - git rev-parse
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Skill output files, scanner reports, CI log paths, or git refs"
+    constraints:
+      type: object
+      properties:
+        required_evidence_kinds:
+          type: array
+          items:
+            type: string
+            enum:
+              - secret-scan
+              - dep-scan
+              - iac-scan
+              - sast-scan
+              - policy-decision
+              - test-results
+              - threat-model
+        min_confidence:
+          type: string
+          enum: [low, medium, high]
+    context:
+      type: object
+      properties:
+        release_ref:
+          type: string
+        environment:
+          type: string
+        actor:
+          type: string
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - evidence
+    - missing_evidence
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      const: "evidence-pack"
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    evidence:
+      type: array
+      items:
+        type: object
+        required: [id, kind, source, status, confidence, ref]
+        properties:
+          id:
+            type: string
+          kind:
+            type: string
+            enum:
+              - secret-scan
+              - dep-scan
+              - iac-scan
+              - sast-scan
+              - policy-decision
+              - test-results
+              - threat-model
+          source:
+            type: string
+          status:
+            type: string
+            enum: [passed, failed, partial, missing]
+          confidence:
+            type: string
+            enum: [high, medium, low]
+          ref:
+            type: string
+            description: "Path or identifier of the underlying artifact"
+          summary:
+            type: string
+          produced_at:
+            type: string
+            format: date-time
+    missing_evidence:
+      type: array
+      items:
+        type: string
+      description: "Kinds of evidence required but not found"
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+    metadata:
+      type: object
+      properties:
+        release_ref:
+          type: string
+        evidence_count:
+          type: integer
+        missing_count:
+          type: integer
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true

--- a/pilot/skills/iac-analysis/prompt.md
+++ b/pilot/skills/iac-analysis/prompt.md
@@ -1,0 +1,98 @@
+# Skill: iac-analysis
+
+## Purpose
+
+Detect misconfigurations and policy violations in infrastructure-as-code.
+Normalize findings from pre-run scanner reports or perform direct rule-based
+analysis on Terraform, Kubernetes, Dockerfile, and similar IaC artifacts.
+
+This skill does not apply Terraform or run containers. It reads and analyzes files.
+
+## Input
+
+- `scope`: IaC directories or file globs (e.g. `infra/`, `**/*.tf`, `k8s/`)
+- `artifacts`: IaC files, Terraform plan JSON, or pre-run checkov/tfsec JSON reports
+- `constraints.frameworks`: optional filter to specific IaC types
+- `constraints.changed_only`: if true, focus on resources touched in the current diff
+- `context.cloud_provider`: helps scope rule selection (aws, gcp, azure)
+
+## Execution steps
+
+1. Locate IaC files within scope using Glob. Detect frameworks from file extensions and content.
+2. If pre-run reports exist in `artifacts`, read and normalize them.
+3. For direct analysis (when no pre-run reports), apply rule checks by framework:
+
+   **Terraform:**
+   - Public storage: `acl = "public-read"` or missing `public_access_block`
+   - Open security groups: `cidr_blocks = ["0.0.0.0/0"]` on sensitive ports
+   - Unencrypted storage: missing `server_side_encryption_configuration`
+   - No versioning on state buckets
+   - IAM wildcard: `"*"` in actions or resources
+
+   **Kubernetes:**
+   - `privileged: true` in securityContext
+   - `hostNetwork: true` or `hostPID: true`
+   - Missing resource limits (cpu/memory)
+   - `runAsRoot` without explicit false
+   - Sensitive env vars without secretKeyRef
+
+   **Dockerfile:**
+   - `USER root` without subsequent USER change
+   - `ADD` with URLs (use COPY instead)
+   - `--no-check-certificate` in RUN steps
+   - Pinned base images: flag `:latest` tags
+
+4. For each finding:
+   a. Assign `rule_id` (use provider rule ids where available; prefix `PILOT-IAC-` for custom rules).
+   b. Map to normalized `type` from `normalization.yaml`.
+   c. Note `is_new_in_diff` if the resource was added or modified in the current change.
+   d. Provide `remediation.guidance`.
+5. Apply `severity_threshold` filter.
+
+## Output contract
+
+Return a JSON object conforming to `skill.yaml#output_schema`.
+
+```json
+{
+  "skill": "iac-analysis",
+  "status": "success",
+  "summary": "4 IaC findings; 2 high-severity public exposure risks in Terraform",
+  "findings": [
+    {
+      "id": "iac-001",
+      "rule_id": "CKV_AWS_20",
+      "severity": "high",
+      "type": "public_bucket",
+      "title": "S3 bucket allows public read access",
+      "path": "infra/s3.tf",
+      "line": 42,
+      "resource_kind": "aws_s3_bucket",
+      "resource_name": "public_assets",
+      "framework": "terraform",
+      "remediation": {
+        "guidance": [
+          "Set acl to private",
+          "Add aws_s3_bucket_public_access_block with all options true"
+        ]
+      },
+      "is_new_in_diff": true,
+      "confidence": "high"
+    }
+  ],
+  "artifacts_used": ["infra/s3.tf", "infra/sg.tf"],
+  "confidence": "high",
+  "metadata": {
+    "files_scanned": 8,
+    "resources_evaluated": 23,
+    "frameworks_detected": ["terraform"]
+  }
+}
+```
+
+## Constraints
+
+- Do not run terraform, kubectl, docker, or any infrastructure tooling.
+- Only use Glob, Read, Grep, and the bash allowlist: `git diff`, `git show`.
+- If pre-run scanner reports are present, prefer normalizing them over re-deriving findings.
+- Do not modify any files.

--- a/pilot/skills/iac-analysis/skill.yaml
+++ b/pilot/skills/iac-analysis/skill.yaml
@@ -1,0 +1,149 @@
+skill_contract_version: "0.1"
+extends: "../_base/contract.yaml"
+
+skill:
+  id: "iac-analysis"
+  category: "analysis"
+  version: "0.1"
+  description: "Detect misconfigurations and policy violations in infrastructure-as-code"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 120
+  max_tool_calls: 10
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist:
+      - git diff
+      - git show
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+      description: "IaC directory paths or file globs"
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "IaC files, Terraform plans, or pre-run checkov/tfsec JSON reports"
+    constraints:
+      type: object
+      properties:
+        severity_threshold:
+          type: string
+          enum: [low, medium, high, critical]
+        frameworks:
+          type: array
+          items:
+            type: string
+            enum: [terraform, cloudformation, kubernetes, helm, dockerfile, bicep]
+        changed_only:
+          type: boolean
+    context:
+      type: object
+      properties:
+        environment:
+          type: string
+        cloud_provider:
+          type: string
+          enum: [aws, gcp, azure, multi, unknown]
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - findings
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      const: "iac-analysis"
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    findings:
+      type: array
+      items:
+        type: object
+        required: [id, rule_id, severity, title, path, resource_kind, resource_name]
+        properties:
+          id:
+            type: string
+          rule_id:
+            type: string
+            description: "Provider rule id, e.g. CKV_AWS_20"
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+          type:
+            type: string
+            description: "Normalized finding type from normalization.yaml"
+          title:
+            type: string
+          path:
+            type: string
+          line:
+            type: integer
+          resource_kind:
+            type: string
+            description: "e.g. aws_s3_bucket, Deployment, SecurityGroup"
+          resource_name:
+            type: string
+          framework:
+            type: string
+            enum: [terraform, cloudformation, kubernetes, helm, dockerfile, bicep]
+          remediation:
+            type: object
+            properties:
+              guidance:
+                type: array
+                items:
+                  type: string
+              reference:
+                type: string
+          is_new_in_diff:
+            type: boolean
+          confidence:
+            type: string
+            enum: [high, medium, low]
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+    metadata:
+      type: object
+      properties:
+        files_scanned:
+          type: integer
+        resources_evaluated:
+          type: integer
+        frameworks_detected:
+          type: array
+          items:
+            type: string
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true

--- a/pilot/skills/policy-eval/prompt.md
+++ b/pilot/skills/policy-eval/prompt.md
@@ -1,0 +1,83 @@
+# Skill: policy-eval
+
+## Purpose
+
+Evaluate normalized findings and facts against policy packs and return a
+structured decision. This skill is the enforcement gate: it translates evidence
+into allow / warn / block / investigate.
+
+This skill does not collect evidence. It only evaluates what is given to it.
+
+## Input
+
+- `artifacts`: normalized `finding/v1` records or prior skill output files
+- `policy_context.packs`: paths to policy pack directories to load
+- `policy_context.environment`, `.branch`, `.actor`: facts used in rule conditions
+- `policy_context.waivers_file`: optional path to active waivers
+- `policy_context.fail_on`: minimum severity that triggers a non-allow decision
+
+## Execution steps
+
+1. Load all rule files from each policy pack directory.
+2. Load waivers from `waivers_file` if provided; filter to non-expired, in-scope waivers.
+3. For each normalized finding in `artifacts`:
+   a. Extract facts: `finding.type`, `finding.severity`, `finding.path`, etc.
+   b. Evaluate matching rules using their `match` conditions.
+   c. Apply waiver if one covers the rule_id and finding scope.
+   d. Collect the rule effect: allow, warn, or block.
+4. Determine the aggregate `decision`:
+   - Any `block` effect → `block`
+   - Any unwaived finding at or above `fail_on` severity → `block`
+   - Any `warn` effect with no blocks → `warn`
+   - Any unevaluable rule without evidence → `investigate`
+   - Otherwise → `allow`
+5. Populate `failed_rules` and `waivers_applied`.
+
+## Condition evaluation
+
+Rules use `match.all`, `match.any`, or `match.none` with these operators:
+`equals`, `not_equals`, `in`, `not_in`, `contains`, `regex`, `gt`, `gte`, `lt`, `lte`
+
+Facts available during evaluation (see `policy/facts.schema.yaml`):
+- `finding.type`, `finding.severity`, `finding.path`
+- `finding.package.name`, `finding.package.version`
+- `finding.network.exposure`, `finding.secret.kind`
+- `policy.context.environment`, `git.branch`, `session.actor`
+
+## Output contract
+
+Return a JSON object conforming to `skill.yaml#output_schema`.
+
+```json
+{
+  "skill": "policy-eval",
+  "status": "success",
+  "summary": "2 rules failed; 1 waiver applied; decision: block",
+  "decision": "block",
+  "failed_rules": [
+    {
+      "rule_id": "no-public-storage",
+      "title": "Disallow public object storage",
+      "severity": "high",
+      "finding_ref": ".pilot-sec/reports/checkov.json#CKV_AWS_20",
+      "effect": "block",
+      "message": "Public buckets are not allowed outside dev"
+    }
+  ],
+  "waivers_applied": [],
+  "artifacts_used": ["policies/default/", ".pilot-sec/reports/checkov.json"],
+  "confidence": "high",
+  "metadata": {
+    "rules_evaluated": 12,
+    "waivers_checked": 3,
+    "pack_sources": ["policies/default", "policies/devsecops"]
+  }
+}
+```
+
+## Constraints
+
+- Do not modify any files.
+- If a policy pack file is missing or malformed, set `status: partial` and continue with available packs.
+- Do not invent rules. Only evaluate rules found in the loaded packs.
+- Expired waivers must not be applied; note them in `metadata`.

--- a/pilot/skills/policy-eval/skill.yaml
+++ b/pilot/skills/policy-eval/skill.yaml
@@ -1,0 +1,151 @@
+skill_contract_version: "0.1"
+extends: "../_base/contract.yaml"
+
+skill:
+  id: "policy-eval"
+  category: "evaluation"
+  version: "0.1"
+  description: "Map evidence (normalized findings and facts) to policy decisions"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 60
+  max_tool_calls: 4
+  allowed_tools:
+    - Read
+    - Glob
+  bash_constraints:
+    deny_destructive: true
+    allowlist: []
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - artifacts
+    - policy_context
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Normalized finding/v1 records or prior skill outputs"
+    policy_context:
+      type: object
+      required:
+        - environment
+        - branch
+        - actor
+        - packs
+      properties:
+        environment:
+          type: string
+        branch:
+          type: string
+        actor:
+          type: string
+        packs:
+          type: array
+          items:
+            type: string
+          description: "Policy pack paths to load (e.g. policies/default)"
+        waivers_file:
+          type: string
+        fail_on:
+          type: string
+          enum: [low, medium, high, critical]
+    constraints:
+      type: object
+    context:
+      type: object
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - decision
+    - failed_rules
+    - waivers_applied
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      const: "policy-eval"
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    decision:
+      type: string
+      enum: [allow, warn, block, investigate]
+    failed_rules:
+      type: array
+      items:
+        type: object
+        required: [rule_id, title, severity, finding_ref, effect]
+        properties:
+          rule_id:
+            type: string
+          title:
+            type: string
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+          finding_ref:
+            type: string
+          effect:
+            type: string
+            enum: [allow, warn, block]
+          message:
+            type: string
+    waivers_applied:
+      type: array
+      items:
+        type: object
+        required: [waiver_id, rule_id, reason, expires_at]
+        properties:
+          waiver_id:
+            type: string
+          rule_id:
+            type: string
+          reason:
+            type: string
+          approved_by:
+            type: string
+          expires_at:
+            type: string
+    passed_rules:
+      type: array
+      items:
+        type: object
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+    metadata:
+      type: object
+      properties:
+        rules_evaluated:
+          type: integer
+        waivers_checked:
+          type: integer
+        pack_sources:
+          type: array
+          items:
+            type: string
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true

--- a/pilot/skills/secret-hygiene/prompt.md
+++ b/pilot/skills/secret-hygiene/prompt.md
@@ -1,0 +1,80 @@
+# Skill: secret-hygiene
+
+## Purpose
+
+Detect, classify, and assess the exposure of secrets in code, config, and git
+history. Produce structured findings and actionable revocation guidance.
+
+This skill does not run external scanners. It performs direct file and pattern
+analysis within its tool allowlist.
+
+## Input
+
+- `scope`: file globs or directories to search
+- `artifacts`: specific files or git refs to analyze
+- `constraints.check_history`: if true, also search git log for secrets introduced then removed
+- `constraints.redact_values`: if true (default), mask secret values in output
+
+## Execution steps
+
+1. Search scope for credential-shaped patterns using Grep and Glob:
+   - High-entropy strings in config files
+   - Known credential prefixes: `ghp_`, `AKIA`, `sk-`, `xoxb-`, `Bearer `, `-----BEGIN`, etc.
+   - Connection strings: `postgres://`, `mysql://`, `mongodb+srv://`
+   - Explicit key/password assignments in .env, .yaml, .json, .toml files
+2. For each candidate:
+   a. Confirm it is not a placeholder (e.g. `<YOUR_KEY>`, `example`, `changeme`, `xxx`).
+   b. Classify by `kind`.
+   c. Assign `severity` based on kind and context (critical: private keys, cloud credentials; high: API tokens, passwords).
+   d. Redact the value: preserve first 4 and last 4 characters, mask remainder with `x`.
+3. If `check_history` is true: run `git log -p --all -S <pattern>` for high-confidence patterns to find historical exposure.
+4. For each confirmed finding, assess exposure:
+   - `likely_live`: true if the credential appears in a live config path (not test fixtures, not clearly revoked).
+   - `blast_radius`: estimate scope of compromise.
+   - `revoke_guidance`: ordered, provider-specific steps (GitHub → Settings > Developer Settings > Tokens; AWS → IAM > Access Keys).
+5. Deduplicate findings across files and history.
+
+## Output contract
+
+Return a JSON object conforming to `skill.yaml#output_schema`.
+
+```json
+{
+  "skill": "secret-hygiene",
+  "status": "success",
+  "summary": "2 secrets detected; 1 likely live GitHub token in .env; 1 historical AWS key revoked",
+  "findings": [
+    {
+      "id": "secret-001",
+      "kind": "api_key",
+      "severity": "critical",
+      "path": ".env",
+      "line": 4,
+      "redacted_value": "ghp_xxxx...xxxx",
+      "confidence": "high",
+      "in_history": false
+    }
+  ],
+  "exposure_assessment": {
+    "likely_live": true,
+    "locations": [".env", "docker-compose.yml"],
+    "revoke_guidance": [
+      "Go to GitHub Settings > Developer Settings > Personal Access Tokens",
+      "Revoke the token matching the detected prefix",
+      "Rotate all services using this token",
+      "Audit access logs for the token since first commit date"
+    ],
+    "blast_radius": "high"
+  },
+  "artifacts_used": [".env", "docker-compose.yml"],
+  "confidence": "high"
+}
+```
+
+## Constraints
+
+- NEVER output unredacted secret values. Always mask the center.
+- Do not access external services to validate whether a secret is live.
+- If `redact_values` is false (unusual), still do not log or surface raw values in summary text.
+- Only use the bash allowlist: `git log`, `git show`, `git diff`, `git grep`.
+- Do not modify any files.

--- a/pilot/skills/secret-hygiene/skill.yaml
+++ b/pilot/skills/secret-hygiene/skill.yaml
@@ -1,0 +1,142 @@
+skill_contract_version: "0.1"
+extends: "../_base/contract.yaml"
+
+skill:
+  id: "secret-hygiene"
+  category: "analysis"
+  version: "0.1"
+  description: "Detect, classify, and assess exposure of secrets in code and config"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 120
+  max_tool_calls: 8
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist:
+      - git log
+      - git show
+      - git diff
+      - git grep
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+    artifacts:
+      type: array
+      items:
+        type: string
+    constraints:
+      type: object
+      properties:
+        check_history:
+          type: boolean
+          description: "Whether to search git history, not just working tree"
+        redact_values:
+          type: boolean
+          default: true
+    context:
+      type: object
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - findings
+    - exposure_assessment
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      const: "secret-hygiene"
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    findings:
+      type: array
+      items:
+        type: object
+        required: [id, kind, severity, path, redacted_value, confidence]
+        properties:
+          id:
+            type: string
+          kind:
+            type: string
+            enum:
+              - api_key
+              - private_key
+              - password
+              - token
+              - certificate
+              - connection_string
+              - oauth_credential
+              - cloud_credential
+              - generic_secret
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+          path:
+            type: string
+          line:
+            type: integer
+          redacted_value:
+            type: string
+            description: "Partial value with center masked, e.g. ghp_xxxx...xxxx"
+          confidence:
+            type: string
+            enum: [high, medium, low]
+          in_history:
+            type: boolean
+            description: "True if found in git history rather than current tree"
+          commit_ref:
+            type: string
+    exposure_assessment:
+      type: object
+      required: [likely_live, locations, revoke_guidance]
+      properties:
+        likely_live:
+          type: boolean
+          description: "Best-effort assessment of whether the secret is still active"
+        locations:
+          type: array
+          items:
+            type: string
+          description: "All paths or refs where the secret appears"
+        revoke_guidance:
+          type: array
+          items:
+            type: string
+          description: "Ordered steps to revoke and rotate the secret"
+        blast_radius:
+          type: string
+          enum: [low, medium, high, critical]
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true

--- a/pilot/skills/threat-modeling/prompt.md
+++ b/pilot/skills/threat-modeling/prompt.md
@@ -1,0 +1,63 @@
+# Skill: threat-modeling
+
+## Purpose
+
+Identify assets, trust boundaries, entry points, and abuse cases from code,
+config, and infrastructure artifacts. This skill produces structured threat
+intelligence that agents use to scope security reviews and prioritize controls.
+
+This skill does not evaluate policy. It identifies what could go wrong and what
+an attacker would target.
+
+## Input
+
+- `objective`: what the caller wants to model (e.g. "identify abuse cases introduced in this PR")
+- `scope`: directory paths or file patterns bounding the analysis
+- `artifacts`: may include diff-analysis output, file paths, architecture docs
+- `constraints.focus`: optional list to narrow to specific domains (auth, network, data, etc.)
+
+## Execution steps
+
+1. Read relevant source files, config, and infra artifacts within scope.
+2. Identify **assets**: what data or capabilities are worth protecting.
+   - Map sensitivity using: critical (secrets, PII, prod credentials), high (auth tokens, internal APIs), medium (user data, config), low (public data, logs).
+3. Identify **trust boundaries**: where control or data crosses between zones.
+   - Examples: internet → API, API → database, CI → production, user → admin, dependency → runtime.
+4. Identify **entry points**: how external actors or data reach the system.
+   - Classify by kind: http, rpc, cli, file, event, webhook, ci-trigger.
+   - Assess authentication and authorization at each point.
+5. Derive **abuse cases**: what an actor could do at each entry point targeting each asset.
+   - Structure each case with actor, technique (MITRE-style if applicable), target asset, severity, and proposed mitigations.
+6. Score severity using the shared scale: low / medium / high / critical.
+
+## Output contract
+
+Return a JSON object conforming to `skill.yaml#output_schema`.
+
+```json
+{
+  "skill": "threat-modeling",
+  "status": "success",
+  "summary": "3 critical assets identified; 2 trust boundaries lack authentication; 4 abuse cases scoped",
+  "assets": [
+    {
+      "id": "asset-001",
+      "name": "Production database credentials",
+      "sensitivity": "critical",
+      "description": "Referenced in .env.prod and CI secrets"
+    }
+  ],
+  "trust_boundaries": [],
+  "entry_points": [],
+  "abuse_cases": [],
+  "artifacts_used": ["infra/", ".github/workflows/deploy.yml"],
+  "confidence": "medium"
+}
+```
+
+## Constraints
+
+- Base analysis on what is present in the artifacts; do not speculate beyond evidence.
+- If scope is a PR diff, focus on threats introduced or modified by the change.
+- Do not duplicate findings from secret-hygiene or dep-analysis; reference them.
+- If artifacts are insufficient to model a boundary, mark it with `risk_hint: unknown` and note in summary.

--- a/pilot/skills/threat-modeling/skill.yaml
+++ b/pilot/skills/threat-modeling/skill.yaml
@@ -1,0 +1,164 @@
+skill_contract_version: "0.1"
+extends: "../_base/contract.yaml"
+
+skill:
+  id: "threat-modeling"
+  category: "analysis"
+  version: "0.1"
+  description: "Identify assets, trust boundaries, entry points, and abuse cases from code and config"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 180
+  max_tool_calls: 12
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist:
+      - git diff
+      - git show
+      - git log
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Changed surfaces output from diff-analysis, file paths, or architecture docs"
+    constraints:
+      type: object
+      properties:
+        focus:
+          type: array
+          items:
+            type: string
+            enum: [auth, network, data, supply-chain, infra, ci]
+    context:
+      type: object
+      properties:
+        environment:
+          type: string
+        actor:
+          type: string
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - assets
+    - trust_boundaries
+    - entry_points
+    - abuse_cases
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      const: "threat-modeling"
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    assets:
+      type: array
+      items:
+        type: object
+        required: [id, name, sensitivity]
+        properties:
+          id:
+            type: string
+          name:
+            type: string
+          sensitivity:
+            type: string
+            enum: [low, medium, high, critical]
+          description:
+            type: string
+    trust_boundaries:
+      type: array
+      items:
+        type: object
+        required: [id, from, to, crossing_mechanism]
+        properties:
+          id:
+            type: string
+          from:
+            type: string
+          to:
+            type: string
+          crossing_mechanism:
+            type: string
+          risk_hint:
+            type: string
+            enum: [low, medium, high, critical]
+    entry_points:
+      type: array
+      items:
+        type: object
+        required: [id, path, kind, authentication]
+        properties:
+          id:
+            type: string
+          path:
+            type: string
+          kind:
+            type: string
+            enum: [http, rpc, cli, file, event, webhook, ci-trigger]
+          authentication:
+            type: string
+            enum: [none, token, oauth, mtls, iam, unknown]
+          authorization:
+            type: string
+    abuse_cases:
+      type: array
+      items:
+        type: object
+        required: [id, title, actor, technique, target_asset, severity]
+        properties:
+          id:
+            type: string
+          title:
+            type: string
+          actor:
+            type: string
+            enum: [external, insider, ci-pipeline, dependency, unknown]
+          technique:
+            type: string
+          target_asset:
+            type: string
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+          mitigations:
+            type: array
+            items:
+              type: string
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true


### PR DESCRIPTION
## Summary

This PR establishes the foundational schema and contract layer for the Pilot security automation framework. It defines the normalized data models, skill execution contracts, and policy evaluation infrastructure that enable composable security analysis across multiple scanner types and tools.

## Key Changes

**Core Schemas:**
- `finding.schema.yaml` - Normalized finding record schema that all scanner adapters must emit, regardless of raw tool output format. Defines required fields (id, source, severity, type, title, location) and optional context objects for packages, secrets, network, and resources.
- `provider.schema.yaml` - Scanner provider configuration schema defining how tools are invoked, error handling strategies, and normalization requirements.
- `rule.schema.yaml` - Policy rule schema for defining security policies with match conditions, effects (allow/warn/block), and remediation guidance.
- `facts.schema.yaml` - Internal fact model that bridges scanner outputs and policy evaluation, keeping provider-specific formats out of the policy layer.
- `waiver.schema.yaml` - Time-bounded, scoped exception schema for policy waivers with approval tracking and expiration.
- `normalization.yaml` - Shared vocabulary for severity levels, confidence ratings, and decision semantics enforced across all skills.

**Skill Contracts:**
- `_base/contract.yaml` - Base contract inherited by all skills, defining common execution constraints (read-only mode, tool allowlists, timeout/call limits) and standard input/output schemas.
- `diff-analysis/skill.yaml` - Extracts security-relevant change signals from git diffs, classifying surfaces by kind (code, config, infra, ci, manifest, secret-surface).
- `secret-hygiene/skill.yaml` - Detects and classifies secrets in code/config with exposure assessment and revocation guidance.
- `dep-analysis/skill.yaml` - Identifies vulnerable, malicious, or policy-violating dependencies from lockfiles and advisories.
- `iac-analysis/skill.yaml` - Detects misconfigurations in infrastructure-as-code across Terraform, Kubernetes, Dockerfile, and other frameworks.
- `threat-modeling/skill.yaml` - Identifies assets, trust boundaries, entry points, and abuse cases from code and infrastructure.
- `policy-eval/skill.yaml` - Maps normalized findings to policy decisions (allow/warn/block/investigate) with waiver support.
- `evidence-pack/skill.yaml` - Collects and normalizes evidence from scanner reports and skill outputs for release gates and audit records.

**Skill Prompts:**
- Added execution guidance documents for each skill (diff-analysis, secret-hygiene, dep-analysis, iac-analysis, threat-modeling, policy-eval, evidence-pack) detailing purpose, input requirements, execution steps, and output expectations.

## Notable Implementation Details

- All skills follow a read-only execution model with bounded tool access (Read, Grep, Glob, Bash with deny-destructive constraints).
- The `finding/v1` schema is the universal normalized format that all scanner adapters must emit, enabling downstream skills and policies to remain tool-agnostic.
- Policy rules evaluate against a fact model derived from normalized findings, not raw scanner output, maintaining clean separation of concerns.
- Waivers are scoped by path, environment, branch, and actor, with mandatory expiration dates and approval attribution.
- Severity and confidence use canonical enumerations with documented mappings from upstream scanner formats (CVSS bands, tool-specific levels).
- Skills are composable: diff-analysis feeds threat-modeling and scopes other analyses; policy-eval consumes normalized findings from any scanner; evidence-pack aggregates skill outputs for audit trails.

https://claude.ai/code/session_01DLBtGLFtbaxkB4xZJg1P4B