### PR TITLE
Add comprehensive schema and skill contracts for security pipeline

### DIFF
--- a/pilot/policy/facts.schema.yaml
+++ b/pilot/policy/facts.schema.yaml
@@ -1,0 +1,164 @@
+# facts.schema.yaml
+# The canonical fact model used by the policy engine.
+# Rules reference facts by name. Skill outputs and scanner adapters must map to these facts.
+# This is the bridge between scanners, agents, and policy — no raw tool output in rules.
+
+version: "0.1"
+
+facts:
+  # ─── Finding facts ───────────────────────────────────────────────────────────
+  finding.type:
+    type: string
+    description: "Normalized finding kind (e.g. public_bucket, hardcoded_secret, vuln_dep)"
+    source: "scanner adapter or skill output"
+
+  finding.severity:
+    type: string
+    enum: [low, medium, high, critical]
+    description: "Normalized severity from normalization.yaml scale"
+    source: "scanner adapter or skill output"
+
+  finding.confidence:
+    type: string
+    enum: [low, medium, high]
+    description: "Confidence in the finding"
+    source: "skill output"
+
+  finding.path:
+    type: string
+    description: "File path where the finding was detected"
+    source: "scanner adapter or skill output"
+
+  finding.line:
+    type: integer
+    description: "Line number within the file"
+    source: "scanner adapter"
+
+  finding.kind:
+    type: string
+    description: "Surface kind (code | config | infra | iac | ci | manifest | secret-surface | dependency | workflow)"
+    source: "diff-analysis or scanner adapter"
+
+  # ─── Package / dependency facts ──────────────────────────────────────────────
+  finding.package.name:
+    type: string
+    description: "Package name for dependency findings"
+    source: "dep-analysis skill"
+
+  finding.package.version:
+    type: string
+    description: "Affected package version"
+    source: "dep-analysis skill"
+
+  finding.package.ecosystem:
+    type: string
+    description: "npm | pypi | go | maven | cargo | etc."
+    source: "dep-analysis skill"
+
+  finding.package.vuln_id:
+    type: string
+    description: "CVE, GHSA, or OSV identifier"
+    source: "dep-analysis skill"
+
+  # ─── Network / exposure facts ─────────────────────────────────────────────────
+  finding.network.exposure:
+    type: string
+    enum: [public, internal, private]
+    description: "Network exposure level of the affected resource"
+    source: "iac-analysis or attack-surface skill"
+
+  finding.network.ports:
+    type: array
+    items:
+      type: integer
+    description: "Exposed network ports"
+    source: "iac-analysis or attack-surface skill"
+
+  # ─── Secret facts ─────────────────────────────────────────────────────────────
+  finding.secret.kind:
+    type: string
+    description: "api-key | token | password | certificate | private-key | connection-string | generic"
+    source: "secret-hygiene skill"
+
+  finding.secret.likely_live:
+    type: boolean
+    description: "Whether the detected secret is likely still valid"
+    source: "secret-hygiene skill"
+
+  # ─── IAC / resource facts ────────────────────────────────────────────────────
+  finding.resource.kind:
+    type: string
+    description: "IaC resource type (e.g. aws_s3_bucket, Deployment)"
+    source: "iac-analysis skill"
+
+  finding.resource.name:
+    type: string
+    description: "IaC resource name or identifier"
+    source: "iac-analysis skill"
+
+  finding.misconfiguration_type:
+    type: string
+    description: "public-exposure | excessive-permissions | missing-encryption | missing-logging | missing-tls | insecure-default"
+    source: "iac-analysis skill"
+
+  # ─── Project context facts ───────────────────────────────────────────────────
+  project.environment:
+    type: string
+    description: "Current environment (dev | staging | prod)"
+    source: "config or session context"
+
+  project.name:
+    type: string
+    description: "Project identifier"
+    source: "config"
+
+  project.type:
+    type: string
+    description: "application | service | library | infra"
+    source: "config"
+
+  # ─── Git facts ───────────────────────────────────────────────────────────────
+  git.branch:
+    type: string
+    description: "Current branch name"
+    source: "git context"
+
+  git.base_ref:
+    type: string
+    description: "Base ref for diff (e.g. main)"
+    source: "git context"
+
+  git.changed_paths:
+    type: array
+    items:
+      type: string
+    description: "Files changed in the current diff"
+    source: "diff-analysis skill"
+
+  # ─── Session / actor facts ───────────────────────────────────────────────────
+  session.actor:
+    type: string
+    description: "Identity performing the action (user, CI bot, etc.)"
+    source: "session context"
+
+  session.trigger:
+    type: string
+    description: "What triggered the run (pr | deploy | scan | manual)"
+    source: "session context"
+
+  # ─── Run facts ───────────────────────────────────────────────────────────────
+  run.command:
+    type: string
+    description: "The command or action being evaluated"
+    source: "runtime"
+
+  run.mode:
+    type: string
+    enum: [observe, warn, enforce]
+    description: "Current policy enforcement mode"
+    source: "config"
+
+  run.timestamp:
+    type: string
+    description: "ISO 8601 timestamp of the evaluation run"
+    source: "runtime"

--- a/pilot/policy/rule.schema.yaml
+++ b/pilot/policy/rule.schema.yaml
@@ -1,0 +1,182 @@
+# rule.schema.yaml
+# Defines the structure of a policy rule.
+# Every rule file used by the policy-eval skill must conform to this schema.
+# Rules evaluate normalized facts — never raw scanner output.
+
+version: "0.1"
+
+schema:
+  type: object
+  required:
+    - id
+    - title
+    - severity
+    - applies_to
+    - match
+    - decision
+  properties:
+
+    id:
+      type: string
+      description: "Unique rule identifier (e.g. no-public-storage)"
+      pattern: "^[a-z][a-z0-9-]*$"
+
+    title:
+      type: string
+      description: "Short human-readable rule name"
+
+    description:
+      type: string
+      description: "Explains what the rule prevents and why it matters"
+
+    severity:
+      type: string
+      enum: [low, medium, high, critical]
+      description: "Baseline severity of a violation"
+
+    applies_to:
+      type: object
+      description: "Scopes this rule to specific events and targets"
+      properties:
+        events:
+          type: array
+          items:
+            type: string
+            enum: [scan, run, deploy, pr, release, manual]
+          description: "Which pipeline events trigger this rule"
+        targets:
+          type: array
+          items:
+            type: string
+            enum: [code, config, iac, cloud, ci, deps, secrets, any]
+          description: "Which finding domains this rule applies to"
+
+    match:
+      type: object
+      description: "Condition tree evaluated against the fact model"
+      # Exactly one of: all, any, none, or a single condition
+      properties:
+        all:
+          type: array
+          items:
+            $ref: "#/condition"
+          description: "All conditions must be true (AND)"
+        any:
+          type: array
+          items:
+            $ref: "#/condition"
+          description: "At least one condition must be true (OR)"
+        none:
+          type: array
+          items:
+            $ref: "#/condition"
+          description: "No conditions may be true (NOT)"
+
+    decision:
+      type: object
+      required: [effect, message]
+      properties:
+        effect:
+          type: string
+          enum: [allow, warn, block]
+          description: "allow = pass; warn = advisory; block = halt gated flow"
+        message:
+          type: string
+          description: "Human-readable explanation shown when rule fires"
+        override_severity:
+          type: string
+          enum: [low, medium, high, critical]
+          description: "Override the baseline severity for this specific match"
+
+    remediation:
+      type: object
+      properties:
+        guidance:
+          type: array
+          items:
+            type: string
+          description: "Ordered remediation steps"
+        links:
+          type: array
+          items:
+            type: string
+          description: "Reference URLs for remediation guidance"
+
+    metadata:
+      type: object
+      properties:
+        tags:
+          type: array
+          items:
+            type: string
+        owner:
+          type: string
+        references:
+          type: array
+          items:
+            type: string
+
+# ─── Condition schema ─────────────────────────────────────────────────────────
+condition:
+  type: object
+  required: [fact, op, value]
+  properties:
+    fact:
+      type: string
+      description: "Fact name from facts.schema.yaml (e.g. finding.severity)"
+    op:
+      type: string
+      enum:
+        - equals
+        - not_equals
+        - in
+        - not_in
+        - contains
+        - regex
+        - gt
+        - gte
+        - lt
+        - lte
+        - exists
+        - not_exists
+      description: "Comparison operator"
+    value:
+      description: "Value to compare against (type depends on fact and op)"
+    # Condition trees can be nested
+    all:
+      type: array
+      description: "Nested AND"
+    any:
+      type: array
+      description: "Nested OR"
+    none:
+      type: array
+      description: "Nested NOT"
+
+# ─── Example rule ─────────────────────────────────────────────────────────────
+example:
+  id: "no-public-storage"
+  title: "Disallow public object storage"
+  description: "Prevent public exposure of storage buckets in managed environments"
+  severity: "high"
+  applies_to:
+    events: [scan, run, deploy, pr]
+    targets: [iac, cloud]
+  match:
+    all:
+      - fact: "finding.type"
+        op: "equals"
+        value: "public_bucket"
+      - fact: "project.environment"
+        op: "in"
+        value: [staging, prod]
+  decision:
+    effect: "block"
+    message: "Public buckets are not allowed outside dev"
+  remediation:
+    guidance:
+      - "Set public_access_block = true"
+      - "Restrict bucket policy principals"
+  metadata:
+    tags: [storage, exposure]
+    owner: "security-team"

--- a/pilot/policy/waiver.schema.yaml
+++ b/pilot/policy/waiver.schema.yaml
@@ -1,0 +1,133 @@
+# waiver.schema.yaml
+# Defines the structure of a policy waiver.
+# Waivers are time-bounded, attributable exceptions to specific rules.
+# They must be structured — no loose comments or untracked exceptions.
+# The policy-eval skill checks waivers before emitting a block decision.
+
+version: "0.1"
+
+schema:
+  type: object
+  required: [waivers]
+  properties:
+    waivers:
+      type: array
+      items:
+        type: object
+        required:
+          - id
+          - rule_id
+          - scope
+          - reason
+          - approved_by
+          - expires_at
+        properties:
+
+          id:
+            type: string
+            description: "Unique waiver identifier (e.g. waiver-001)"
+            pattern: "^waiver-[a-z0-9-]+$"
+
+          rule_id:
+            type: string
+            description: "The rule ID this waiver covers (must match a rule in the active pack)"
+
+          scope:
+            type: object
+            description: "Limits where this waiver applies. Narrower is better."
+            properties:
+              paths:
+                type: array
+                items:
+                  type: string
+                description: "File paths or glob patterns where the waiver applies"
+              environments:
+                type: array
+                items:
+                  type: string
+                  enum: [dev, staging, prod, any]
+                description: "Environments where the waiver applies"
+              branches:
+                type: array
+                items:
+                  type: string
+                description: "Git branches where the waiver applies"
+              actors:
+                type: array
+                items:
+                  type: string
+                description: "Specific actors the waiver applies to"
+
+          reason:
+            type: string
+            description: "Business justification for the exception. Must be specific, not generic."
+
+          approved_by:
+            type: string
+            description: "Identity of the approver (person or team)"
+
+          approved_at:
+            type: string
+            format: date-time
+            description: "ISO 8601 timestamp when the waiver was approved"
+
+          expires_at:
+            type: string
+            format: date-time
+            description: "ISO 8601 timestamp when the waiver expires. Expired waivers are not honored."
+
+          tracking:
+            type: object
+            description: "Links to issue/ticket tracking the remediation"
+            properties:
+              issue:
+                type: string
+                description: "Issue or ticket URL or ID"
+              due_date:
+                type: string
+                format: date
+                description: "Target date to resolve the underlying issue"
+
+          conditions:
+            type: array
+            items:
+              type: string
+            description: "Conditions that must remain true for this waiver to apply (e.g. 'only for static assets')"
+
+# ─── Waiver evaluation rules ──────────────────────────────────────────────────
+evaluation_rules:
+  expiry:
+    description: "Waivers past expires_at are not honored. The policy-eval skill must check this."
+    action: "Treat expired waiver as absent; re-evaluate the rule without it."
+
+  scope_match:
+    description: "All scope fields must match the current context for the waiver to apply."
+    fields:
+      - "paths: current finding.path must match one of the scope paths (supports glob)"
+      - "environments: project.environment must be in scope.environments"
+      - "branches: git.branch must be in scope.branches (if specified)"
+      - "actors: session.actor must be in scope.actors (if specified)"
+
+  audit:
+    description: "Every waiver evaluation (applied or rejected) must be included in policy-eval output."
+
+# ─── Example waiver file ──────────────────────────────────────────────────────
+example:
+  waivers:
+    - id: "waiver-001"
+      rule_id: "no-public-storage"
+      scope:
+        paths:
+          - "infra/dev/public-assets.tf"
+        environments:
+          - "dev"
+      reason: "Temporary public asset hosting for static marketing content during migration to CDN. CDN migration tracked in issue #342."
+      approved_by: "esteban"
+      approved_at: "2026-01-15T09:00:00Z"
+      expires_at: "2026-06-30T00:00:00Z"
+      tracking:
+        issue: "https://github.com/org/repo/issues/342"
+        due_date: "2026-06-01"
+      conditions:
+        - "Applies only to infra/dev/ — never staging or prod"
+        - "Assets must be non-sensitive (no PII, no credentials)"

--- a/pilot/scanners/finding.schema.yaml
+++ b/pilot/scanners/finding.schema.yaml
@@ -1,0 +1,198 @@
+# finding.schema.yaml
+# The normalized finding record emitted by all scanner adapters.
+# Every provider (gitleaks, checkov, semgrep, osv, etc.) must map its raw output
+# to this schema before passing findings to skills or the policy engine.
+# This schema is the contract between scanner adapters and the rest of the system.
+
+version: "0.1"
+schema: "finding/v1"
+
+schema:
+  type: object
+  required:
+    - schema
+    - id
+    - source
+    - severity
+    - type
+    - title
+    - location
+    - evidence
+  properties:
+
+    schema:
+      type: string
+      const: "finding/v1"
+      description: "Schema version identifier"
+
+    id:
+      type: string
+      description: "Unique finding ID within this scan run (e.g. finding-001)"
+
+    # ─── Source provenance ───────────────────────────────────────────────────
+    source:
+      type: object
+      required: [scanner_type, provider]
+      properties:
+        scanner_type:
+          type: string
+          enum: [secrets, iac, deps, sast, code, network, custom]
+        provider:
+          type: string
+          description: "Tool that produced the finding (gitleaks | checkov | semgrep | osv | tfsec | kube-score)"
+        rule_id:
+          type: string
+          description: "Provider-native rule or check ID (e.g. CKV_AWS_20, CVE-2021-23337)"
+        rule_name:
+          type: string
+          description: "Human-readable rule name from the provider"
+
+    # ─── Classification ─────────────────────────────────────────────────────
+    severity:
+      type: string
+      enum: [low, medium, high, critical]
+      description: "Normalized severity — must use normalization.yaml scale"
+
+    type:
+      type: string
+      description: "Normalized finding type (e.g. public_bucket, hardcoded_secret, vuln_dep)"
+      # Provider-specific types must be mapped to normalized types by the adapter
+
+    title:
+      type: string
+      description: "Short human-readable finding title"
+
+    confidence:
+      type: string
+      enum: [low, medium, high]
+
+    # ─── Location ───────────────────────────────────────────────────────────
+    location:
+      type: object
+      required: [path]
+      properties:
+        path:
+          type: string
+          description: "Relative file path from repo root"
+        line:
+          type: integer
+          description: "Line number (1-indexed)"
+        line_end:
+          type: integer
+          description: "End line number for multi-line findings"
+        column:
+          type: integer
+
+    # ─── Resource (IaC / cloud) ──────────────────────────────────────────────
+    resource:
+      type: object
+      description: "Applicable to IaC and cloud findings"
+      properties:
+        kind:
+          type: string
+          description: "Resource type (e.g. aws_s3_bucket, Deployment)"
+        name:
+          type: string
+          description: "Resource name or identifier"
+        environment:
+          type: string
+
+    # ─── Package (dependency findings) ───────────────────────────────────────
+    package:
+      type: object
+      description: "Applicable to dependency findings"
+      properties:
+        name:
+          type: string
+        version:
+          type: string
+        ecosystem:
+          type: string
+          description: "npm | pypi | go | maven | cargo"
+        vuln_id:
+          type: string
+          description: "CVE, GHSA, or OSV ID"
+        fixed_in:
+          type: string
+        is_transitive:
+          type: boolean
+
+    # ─── Secret (secret findings) ────────────────────────────────────────────
+    secret:
+      type: object
+      description: "Applicable to secret/credential findings"
+      properties:
+        kind:
+          type: string
+          description: "api-key | token | password | certificate | private-key | connection-string | generic"
+        redacted:
+          type: boolean
+          const: true
+          description: "Always true — raw secret values must never appear in normalized findings"
+        likely_live:
+          type: boolean
+
+    # ─── Evidence ───────────────────────────────────────────────────────────
+    evidence:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+          description: "What the scanner detected and why it matters"
+        raw_ref:
+          type: string
+          description: "Reference to raw scanner output: <report_path>#<rule_or_finding_id>"
+          # Example: ".pilot-sec/reports/checkov.json#CKV_AWS_20"
+        snippet:
+          type: string
+          description: "Relevant code or config snippet — must be redacted if it contains secret material"
+
+    # ─── Remediation ────────────────────────────────────────────────────────
+    remediation:
+      type: object
+      properties:
+        guidance:
+          type: array
+          items:
+            type: string
+        links:
+          type: array
+          items:
+            type: string
+
+    # ─── Suppression ────────────────────────────────────────────────────────
+    suppressed:
+      type: boolean
+      description: "True if this finding is suppressed by an inline annotation or ignore file"
+
+    suppression_reason:
+      type: string
+      description: "Why the finding was suppressed"
+
+# ─── Example normalized finding ──────────────────────────────────────────────
+example:
+  schema: "finding/v1"
+  id: "finding-001"
+  source:
+    scanner_type: "iac"
+    provider: "checkov"
+    rule_id: "CKV_AWS_20"
+    rule_name: "Ensure S3 bucket does not allow public read access"
+  severity: "high"
+  type: "public_bucket"
+  title: "S3 bucket allows public read access"
+  confidence: "high"
+  location:
+    path: "infra/s3.tf"
+    line: 42
+  resource:
+    kind: "aws_s3_bucket"
+    name: "public_assets"
+  evidence:
+    message: "Public ACL detected; bucket allows public read via acl = \"public-read\""
+    raw_ref: ".pilot-sec/reports/checkov.json#CKV_AWS_20"
+  remediation:
+    guidance:
+      - "Remove acl = \"public-read\""
+      - "Add aws_s3_bucket_public_access_block"

--- a/pilot/scanners/provider.schema.yaml
+++ b/pilot/scanners/provider.schema.yaml
@@ -1,0 +1,237 @@
+# provider.schema.yaml
+# Defines the configuration schema for scanner provider entries.
+# Each scanner type (secrets, deps, iac, sast) is fulfilled by a provider.
+# Providers are configured in the main pilot-sec config under scanners.providers.
+# All provider adapters must normalize output to finding/v1 (finding.schema.yaml).
+
+version: "0.1"
+
+schema:
+  type: object
+  description: "A single provider configuration block"
+  required:
+    - provider
+    - mode
+    - normalize_to
+  properties:
+
+    provider:
+      type: string
+      description: "Tool identifier"
+      enum:
+        - gitleaks
+        - truffelhog
+        - osv
+        - grype
+        - trivy
+        - checkov
+        - tfsec
+        - semgrep
+        - bandit
+        - kube-score
+        - custom
+
+    mode:
+      type: string
+      enum: [blocking, advisory, disabled]
+      description: |
+        blocking: findings at or above severity_threshold halt gated flows
+        advisory: findings are reported but never block
+        disabled: provider is configured but not run
+
+    normalize_to:
+      type: string
+      const: "finding/v1"
+      description: "All providers must normalize to finding/v1"
+
+    timeout_seconds:
+      type: integer
+      default: 120
+      description: "Per-provider timeout; overrides global scanner timeout"
+
+    config_file:
+      type: string
+      description: "Path to provider-specific config file (e.g. .gitleaks.toml)"
+
+    paths:
+      type: array
+      items:
+        type: string
+      description: "File paths or globs to scan; defaults to repo root"
+
+    lockfiles:
+      type: array
+      items:
+        type: string
+      description: "Lock files to analyze (dep providers only)"
+
+    rulesets:
+      type: array
+      items:
+        type: string
+      description: "Ruleset identifiers (sast providers)"
+
+    on_error:
+      type: object
+      description: "Behavior when the provider fails"
+      properties:
+        strategy:
+          type: string
+          enum: [fail-open, fail-closed, warn]
+          default: "fail-closed"
+          description: |
+            fail-open: treat as no findings; proceed
+            fail-closed: treat as blocking error; halt
+            warn: log and continue
+        message:
+          type: string
+          description: "Message to include when error strategy fires"
+
+    args:
+      type: object
+      description: "Provider-specific arguments passed to the tool"
+      # Shape is provider-specific; see per-provider examples below
+
+# ─── Per-provider args reference ─────────────────────────────────────────────
+
+provider_args:
+  gitleaks:
+    redact:
+      type: boolean
+      default: true
+      description: "Redact secret values from output"
+    staged:
+      type: boolean
+      default: false
+      description: "Scan staged changes only (pre-commit mode)"
+    baseline_path:
+      type: string
+      description: "Path to baseline JSON to suppress known findings"
+
+  osv:
+    include_transitive:
+      type: boolean
+      default: true
+      description: "Include transitive dependency vulnerabilities"
+    skip_unsupported:
+      type: boolean
+      default: false
+      description: "Skip lock files for unsupported ecosystems"
+
+  checkov:
+    framework:
+      type: array
+      items:
+        type: string
+        enum: [terraform, kubernetes, cloudformation, arm, bicep, dockerfile, github_actions]
+    skip_checks:
+      type: array
+      items:
+        type: string
+      description: "Checkov check IDs to skip (prefer waivers over blanket skips)"
+    compact:
+      type: boolean
+      default: true
+
+  semgrep:
+    config:
+      type: array
+      items:
+        type: string
+        description: "Semgrep ruleset or config path (auto | p/security-audit | etc.)"
+    exclude:
+      type: array
+      items:
+        type: string
+      description: "Paths to exclude"
+    severity:
+      type: string
+      enum: [INFO, WARNING, ERROR]
+      default: "WARNING"
+
+  tfsec:
+    minimum_severity:
+      type: string
+      enum: [LOW, MEDIUM, HIGH, CRITICAL]
+    include_passed:
+      type: boolean
+      default: false
+
+  grype:
+    scope:
+      type: string
+      enum: [squashed, all-layers]
+      default: "squashed"
+    only_fixed:
+      type: boolean
+      default: false
+
+  trivy:
+    scanners:
+      type: array
+      items:
+        type: string
+        enum: [vuln, secret, config, license]
+    ignore_unfixed:
+      type: boolean
+      default: false
+
+# ─── Full provider configuration examples ────────────────────────────────────
+
+examples:
+  secrets_provider:
+    provider: "gitleaks"
+    mode: "blocking"
+    normalize_to: "finding/v1"
+    timeout_seconds: 120
+    config_file: ".pilot-sec/providers/gitleaks.toml"
+    on_error:
+      strategy: "fail-closed"
+      message: "Secret scan failed; blocking as missing evidence"
+    args:
+      redact: true
+      staged: false
+
+  deps_provider:
+    provider: "osv"
+    mode: "advisory"
+    normalize_to: "finding/v1"
+    timeout_seconds: 180
+    lockfiles:
+      - "package-lock.json"
+      - "poetry.lock"
+    on_error:
+      strategy: "warn"
+      message: "Dependency scan failed; proceeding with advisory"
+    args:
+      include_transitive: true
+
+  iac_provider:
+    provider: "checkov"
+    mode: "blocking"
+    normalize_to: "finding/v1"
+    timeout_seconds: 180
+    paths:
+      - "infra/"
+      - "terraform/"
+    on_error:
+      strategy: "fail-closed"
+      message: "IaC scan failed; blocking deploy due to missing evidence"
+    args:
+      framework:
+        - terraform
+        - kubernetes
+      compact: true
+
+  sast_provider:
+    provider: "semgrep"
+    mode: "advisory"
+    normalize_to: "finding/v1"
+    timeout_seconds: 240
+    on_error:
+      strategy: "warn"
+    args:
+      config:
+        - "p/security-audit"
+        - "p/secrets"
+      severity: "WARNING"

--- a/pilot/skills/_base/contract.yaml
+++ b/pilot/skills/_base/contract.yaml
@@ -1,0 +1,102 @@
+skill_contract_version: "0.1"
+
+# Base contract inherited by every skill.
+# Each skill specializes input_schema, output_schema, and execution constraints.
+# Skills never call agents. Agents call skills. The dependency graph is acyclic.
+
+execution:
+  mode: "read-only"             # read-only | bounded-write
+  timeout_seconds: 120
+  max_tool_calls: 6
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist: []               # Each skill declares its own allowlist
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+      description: "What the skill must accomplish in this invocation"
+    scope:
+      type: array
+      items:
+        type: string
+      description: "Paths, globs, or identifiers bounding the work"
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Evidence inputs — files, reports, SBOMs, scan results, etc."
+    constraints:
+      type: object
+      description: "Optional runtime constraints (e.g. max_findings, severity_filter)"
+    context:
+      type: object
+      description: "Optional ambient context (git.branch, session.actor, environment)"
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - findings
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      description: "Skill ID that produced this output"
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+      description: "Human-readable summary of what was found or decided"
+    findings:
+      type: array
+      items:
+        type: object
+      description: "Structured results; shape is skill-specific"
+    artifacts_used:
+      type: array
+      items:
+        type: string
+      description: "Artifact paths actually consumed during execution"
+    confidence:
+      type: string
+      enum: [high, medium, low]
+    errors:
+      type: array
+      items:
+        type: string
+      description: "Errors encountered during partial execution"
+    metadata:
+      type: object
+      description: "Skill-specific supplementary data"
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true
+  # On hard failure, still emit status: failed with whatever was collected.
+  # Never silently discard evidence.
+
+normalization:
+  # All skills use the same vocabulary so agents can compose without translation.
+  severity_scale: [low, medium, high, critical]
+  confidence_scale: [low, medium, high]
+  decision_scale: [allow, warn, block, investigate]
+  # Severity mapping guidance:
+  #   low:      informational, no immediate action needed
+  #   medium:   should be addressed before release
+  #   high:     must be addressed; blocks in enforce mode
+  #   critical: immediate action required; always blocks

--- a/pilot/skills/_base/normalization.yaml
+++ b/pilot/skills/_base/normalization.yaml
@@ -1,0 +1,74 @@
+# Shared normalization vocabulary for all skills.
+# Every skill that emits findings MUST map to these scales and kinds.
+# This file is the single source of truth for cross-skill comparability.
+
+version: "0.1"
+
+severity:
+  scale: [low, medium, high, critical]
+  definitions:
+    low:      "Informational. No immediate risk. Document and monitor."
+    medium:   "Risk present but exploitability is limited or conditional."
+    high:     "Significant risk; must remediate before release."
+    critical: "Immediate action required. Blocks all gated flows."
+
+confidence:
+  scale: [low, medium, high]
+  definitions:
+    low:    "Signal is ambiguous or derived from incomplete evidence."
+    medium: "Signal is plausible with supporting evidence but not definitive."
+    high:   "Signal is well-supported by direct evidence."
+
+decision:
+  scale: [allow, warn, block, investigate]
+  definitions:
+    allow:       "No action required. Proceed."
+    warn:        "Proceed with advisory logged. Human review recommended."
+    block:       "Halt gated flow. Requires remediation or approved waiver."
+    investigate: "Insufficient evidence to decide. Escalate for manual review."
+
+finding_kinds:
+  # Canonical kind vocabulary shared across all skill outputs.
+  # code surface
+  - code
+  - config
+  - secret-surface
+  # infrastructure
+  - infra
+  - iac
+  - cloud
+  # supply chain
+  - dependency
+  - manifest
+  # pipeline
+  - ci
+  - workflow
+  # runtime
+  - network-exposure
+  - permission
+
+finding_schema: "finding/v1"
+# Reference: pilot/scanners/finding.schema.yaml
+
+evidence_ref_format: "<report_path>#<rule_or_finding_id>"
+# Example: ".pilot-sec/reports/checkov.json#CKV_AWS_20"
+
+# Severity mapping from common tool outputs:
+tool_severity_map:
+  gitleaks:
+    HIGH: high
+    MEDIUM: medium
+    LOW: low
+  checkov:
+    HIGH: high
+    MEDIUM: medium
+    LOW: low
+  semgrep:
+    ERROR: critical
+    WARNING: high
+    INFO: low
+  osv:
+    CRITICAL: critical
+    HIGH: high
+    MODERATE: medium
+    LOW: low

--- a/pilot/skills/attack-surface/prompt.md
+++ b/pilot/skills/attack-surface/prompt.md
@@ -1,0 +1,84 @@
+# attack-surface
+
+**Category:** analysis
+**Contract:** `pilot/skills/_base/contract.yaml`
+**Schema:** `pilot/skills/attack-surface/skill.yaml`
+
+## Purpose
+
+Map the external and internal attack surface exposed by the system or by a specific change. Enumerate API endpoints, permissions, and network exposure. This feeds threat modeling and policy evaluation — it does not make decisions.
+
+## Execution Instructions
+
+1. **Load inputs.** Read API specs (OpenAPI, GraphQL schema), source routes, IaC files, and `context.changed_surfaces` from diff-analysis if available.
+
+2. **Enumerate endpoints.** For each route or API endpoint:
+   - Record `path`, `method`
+   - Determine `auth_required` (look for auth middleware, guards, decorators)
+   - Determine `accepts_input` (request body, query params, file uploads)
+   - Assign `risk_hint`:
+     - `critical`: unauthenticated write, file upload, exec, admin action
+     - `high`: authenticated write to sensitive resource, bulk operations
+     - `medium`: authenticated read, filtered queries
+     - `low`: static content, health checks
+
+3. **Map permissions.** For IAM roles, service accounts, and RBAC rules:
+   - Identify `principal`, `resource`, `action`
+   - Assess `scope_risk` (wildcard `*` → critical, broad resource → high, scoped → low/medium)
+
+4. **Assess network exposure.** For each resource with network configuration:
+   - Determine if `public`, `internal`, or `private`
+   - List open `ports`
+   - Assign `risk_hint`
+
+5. **Emit findings.** Flag specific concerns:
+   - Unauthenticated endpoints that accept input
+   - Overly broad permissions (wildcard principals or actions)
+   - Publicly exposed management ports (22, 3389, 5432, etc.)
+   - New endpoints added in the current change
+
+6. **Emit output.** Produce a valid output matching the schema.
+
+## Output Contract
+
+```yaml
+skill: "attack-surface"
+status: success
+summary: "12 endpoints mapped; 2 unauthenticated write endpoints (high risk). 1 public management port (critical)."
+endpoints:
+  - id: "ep-001"
+    path: "/api/v1/upload"
+    method: "POST"
+    auth_required: false
+    risk_hint: "critical"
+    accepts_input: true
+    description: "Unauthenticated file upload endpoint"
+permissions:
+  - id: "perm-001"
+    principal: "ci-runner"
+    resource: "*"
+    action: "s3:*"
+    scope_risk: "critical"
+    description: "CI runner has full S3 access; should be scoped to deployment bucket"
+network_exposure:
+  - resource: "ec2/bastion"
+    exposure: "public"
+    ports: [22, 3389]
+    risk_hint: "high"
+findings:
+  - id: "as-001"
+    severity: "critical"
+    description: "POST /api/v1/upload accepts file uploads without authentication"
+    path: "src/routes/upload.ts"
+artifacts_used:
+  - "src/routes/upload.ts"
+  - "infra/iam.tf"
+confidence: "medium"
+```
+
+## Constraints
+
+- Do not make policy decisions; map and flag only.
+- If `constraints.changed_only` is true, focus on endpoints and permissions introduced or modified in the current diff.
+- If `constraints.include_internal` is false, omit internal-only endpoints.
+- Do not attempt live probing or network scanning.

--- a/pilot/skills/attack-surface/skill.yaml
+++ b/pilot/skills/attack-surface/skill.yaml
@@ -1,0 +1,153 @@
+skill_contract_version: "0.1"
+
+skill:
+  id: "attack-surface"
+  category: "analysis"
+  version: "0.1"
+  description: "Map the external and internal attack surface exposed by the system or change"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 120
+  max_tool_calls: 8
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist:
+      - "git diff"
+      - "git show"
+      - "git log"
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Source files, API specs, IaC, diff-analysis output"
+    constraints:
+      type: object
+      properties:
+        changed_only:
+          type: boolean
+          default: false
+        include_internal:
+          type: boolean
+          default: true
+    context:
+      type: object
+      properties:
+        changed_surfaces:
+          type: array
+          description: "Output from diff-analysis skill"
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - endpoints
+    - permissions
+    - network_exposure
+    - findings
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      enum: ["attack-surface"]
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    endpoints:
+      type: array
+      items:
+        type: object
+        required: [id, path, method, auth_required, risk_hint]
+        properties:
+          id:
+            type: string
+          path:
+            type: string
+          method:
+            type: string
+          auth_required:
+            type: boolean
+          risk_hint:
+            type: string
+            enum: [low, medium, high, critical]
+          accepts_input:
+            type: boolean
+          description:
+            type: string
+    permissions:
+      type: array
+      items:
+        type: object
+        required: [id, principal, resource, action, scope_risk]
+        properties:
+          id:
+            type: string
+          principal:
+            type: string
+          resource:
+            type: string
+          action:
+            type: string
+          scope_risk:
+            type: string
+            enum: [low, medium, high, critical]
+          description:
+            type: string
+    network_exposure:
+      type: array
+      items:
+        type: object
+        properties:
+          resource:
+            type: string
+          exposure:
+            type: string
+            enum: [public | internal | private]
+          ports:
+            type: array
+            items:
+              type: integer
+          risk_hint:
+            type: string
+            enum: [low, medium, high, critical]
+    findings:
+      type: array
+      items:
+        type: object
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true
+
+normalization:
+  ref: "pilot/skills/_base/normalization.yaml"

--- a/pilot/skills/dep-analysis/prompt.md
+++ b/pilot/skills/dep-analysis/prompt.md
@@ -1,0 +1,71 @@
+# dep-analysis
+
+**Category:** analysis
+**Contract:** `pilot/skills/_base/contract.yaml`
+**Schema:** `pilot/skills/dep-analysis/skill.yaml`
+
+## Purpose
+
+Analyze project dependencies for known vulnerabilities, license risk, and supply chain signals. Consume pre-existing scan reports when available; fall back to reading lock files directly. Produce normalized findings for agent consumption.
+
+## Execution Instructions
+
+1. **Load inputs.** Check `artifacts` for osv-scanner output, npm audit JSON, or SBOM files. If none, locate lock files in `scope` paths:
+   - `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml` (Node)
+   - `poetry.lock`, `requirements.txt`, `Pipfile.lock` (Python)
+   - `go.sum`, `go.mod` (Go)
+   - `Cargo.lock` (Rust)
+
+2. **Parse vulnerabilities.** For each vulnerability in the reports or lock files:
+   - Extract `package_name`, `package_version`, `ecosystem`
+   - Map to `vuln_id` (CVE, GHSA, OSV)
+   - Normalize severity using `normalization.yaml` tool_severity_map
+   - Note `fixed_in` version if available
+   - Mark `is_transitive` if not a direct dependency
+
+3. **Identify supply chain signals.** Look for:
+   - Typosquatting patterns (names very similar to popular packages)
+   - Packages with no published provenance (no SIGSTORE signature)
+   - Recently abandoned packages (last release very old, archived)
+   - Recent maintainer transfers
+
+4. **If `context.changed_only` or diff is available:** Identify `newly_added` packages from the diff.
+
+5. **Emit output.** Produce a valid output matching the schema.
+
+## Output Contract
+
+```yaml
+skill: "dep-analysis"
+status: success
+summary: "3 vulnerabilities found: 1 critical (lodash RCE), 2 high. 1 supply chain signal: recent maintainer change in dep-x."
+findings:
+  - id: "dep-001"
+    severity: "critical"
+    package_name: "lodash"
+    package_version: "4.17.19"
+    ecosystem: "npm"
+    vuln_id: "CVE-2021-23337"
+    description: "Prototype pollution via _.zipObjectDeep; RCE possible in some configurations"
+    fixed_in: "4.17.21"
+    is_transitive: false
+    evidence_ref: ".pilot-sec/reports/osv-results.json#CVE-2021-23337"
+supply_chain_signals:
+  - package_name: "dep-x"
+    signal: "recent-maintainer-change"
+    severity: "medium"
+newly_added:
+  - "some-new-package@1.0.0"
+artifacts_used:
+  - ".pilot-sec/reports/osv-results.json"
+  - "package-lock.json"
+confidence: "high"
+```
+
+## Constraints
+
+- Do not run package managers or install packages.
+- Do not make policy decisions; emit findings only.
+- Filter findings to `constraints.severity_filter` threshold when provided.
+- If `constraints.include_transitive` is false, omit transitive findings.
+- Emit `status: partial` if some lock files were unreadable.

--- a/pilot/skills/dep-analysis/skill.yaml
+++ b/pilot/skills/dep-analysis/skill.yaml
@@ -1,0 +1,134 @@
+skill_contract_version: "0.1"
+
+skill:
+  id: "dep-analysis"
+  category: "analysis"
+  version: "0.1"
+  description: "Analyze dependencies for known vulnerabilities, license risk, and supply chain signals"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 120
+  max_tool_calls: 8
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist:
+      - "git diff"
+      - "git show"
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Lock files, SBOM files, osv-scanner output, npm audit output"
+    constraints:
+      type: object
+      properties:
+        severity_filter:
+          type: string
+          enum: [low, medium, high, critical]
+        include_transitive:
+          type: boolean
+          default: true
+        changed_only:
+          type: boolean
+          default: false
+    context:
+      type: object
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - findings
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      enum: ["dep-analysis"]
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    findings:
+      type: array
+      items:
+        type: object
+        required: [id, severity, package_name, package_version, vuln_id, description]
+        properties:
+          id:
+            type: string
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+          package_name:
+            type: string
+          package_version:
+            type: string
+          ecosystem:
+            type: string
+            description: "npm | pypi | go | maven | cargo | etc."
+          vuln_id:
+            type: string
+            description: "CVE, GHSA, or OSV ID"
+          description:
+            type: string
+          fixed_in:
+            type: string
+          is_transitive:
+            type: boolean
+          evidence_ref:
+            type: string
+    supply_chain_signals:
+      type: array
+      items:
+        type: object
+        properties:
+          package_name:
+            type: string
+          signal:
+            type: string
+            description: "typosquat | abandoned | recent-maintainer-change | no-provenance"
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+    newly_added:
+      type: array
+      items:
+        type: string
+      description: "Packages added in this diff (if changed_only context available)"
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true
+
+normalization:
+  ref: "pilot/skills/_base/normalization.yaml"

--- a/pilot/skills/diff-analysis/prompt.md
+++ b/pilot/skills/diff-analysis/prompt.md
@@ -1,0 +1,70 @@
+# diff-analysis
+
+**Category:** analysis
+**Contract:** `pilot/skills/_base/contract.yaml`
+**Schema:** `pilot/skills/diff-analysis/skill.yaml`
+
+## Purpose
+
+Derive the security-relevant change surface from git diffs and changed files. Identify what changed, classify each changed surface by kind and risk, and surface findings that warrant further investigation by downstream agents or skills.
+
+This skill does not make policy decisions. It produces structured change signal that agents and policy-eval consume.
+
+## Execution Instructions
+
+1. **Collect the diff.** Use `git diff`, `git show`, or read provided artifact files to gather the full change set. Respect `context.base_ref` and `context.head_ref` if provided.
+
+2. **Enumerate changed surfaces.** For each changed file, determine:
+   - `path`: relative path from repo root
+   - `kind`: classify as one of — `code`, `config`, `infra`, `iac`, `ci`, `manifest`, `secret-surface`, `dependency`, `workflow`
+   - `risk_hint`: assign using these heuristics:
+     - `critical`: auth, crypto, secrets management, IAM, network exposure config
+     - `high`: security controls, input validation, privilege logic, prod infra
+     - `medium`: config changes, dependency updates, CI changes
+     - `low`: docs, tests, formatting, comments
+
+3. **Scan for findings.** Within the diff, look for:
+   - Newly introduced secrets or credential patterns
+   - Security control removals or bypasses (e.g., removing auth middleware, disabling TLS)
+   - Dangerous function introductions (eval, exec, subprocess with user input)
+   - Dependency additions — note name and check for known-suspicious patterns
+   - Infrastructure changes that increase exposure (public ACLs, open security groups)
+   - CI workflow changes that add new permissions, network access, or external calls
+
+4. **Emit output.** Produce a valid output matching `output_schema` in `skill.yaml`:
+   - `changed_surfaces`: one entry per changed file
+   - `findings`: one entry per signal worth flagging, with `severity`, `kind`, `path`, `description`, `evidence_ref`
+   - `summary`: one paragraph synthesizing the change surface and any notable findings
+   - `confidence`: overall confidence in the analysis
+
+## Output Contract
+
+```yaml
+skill: "diff-analysis"
+status: success | partial | failed
+summary: "<paragraph>"
+changed_surfaces:
+  - path: "src/auth/middleware.ts"
+    kind: "code"
+    risk_hint: "critical"
+    lines_changed: 42
+    rationale: "Modifies authentication middleware"
+findings:
+  - id: "da-001"
+    severity: "high"
+    kind: "code"
+    path: "src/auth/middleware.ts"
+    description: "Auth bypass condition introduced on line 88"
+    evidence_ref: "git diff HEAD~1..HEAD -- src/auth/middleware.ts#L88"
+artifacts_used:
+  - "git diff HEAD~1..HEAD"
+confidence: "high"
+```
+
+## Constraints
+
+- Do not make policy decisions. Emit findings, not verdicts.
+- Do not modify any files.
+- Redact any actual secret values in `description` or `evidence_ref`.
+- If the diff is unavailable, emit `status: failed` with an error.
+- Limit findings to signals with `severity >= medium` unless `constraints.severity_filter` overrides.

--- a/pilot/skills/diff-analysis/skill.yaml
+++ b/pilot/skills/diff-analysis/skill.yaml
@@ -1,0 +1,133 @@
+skill_contract_version: "0.1"
+
+skill:
+  id: "diff-analysis"
+  category: "analysis"
+  version: "0.1"
+  description: "Extract security-relevant change signals from a diff"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 120
+  max_tool_calls: 6
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist:
+      - "git diff"
+      - "git status"
+      - "git show"
+      - "git log"
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+      description: "Paths or globs to analyze"
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Diff files, patch files, or git refs"
+    constraints:
+      type: object
+      properties:
+        severity_filter:
+          type: string
+          enum: [low, medium, high, critical]
+        changed_only:
+          type: boolean
+          default: true
+    context:
+      type: object
+      properties:
+        base_ref:
+          type: string
+        head_ref:
+          type: string
+        pr_number:
+          type: string
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - changed_surfaces
+    - findings
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      enum: ["diff-analysis"]
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    changed_surfaces:
+      type: array
+      items:
+        type: object
+        required: [path, kind, risk_hint]
+        properties:
+          path:
+            type: string
+          kind:
+            type: string
+            enum: [code, config, infra, ci, manifest, secret-surface, iac, dependency, workflow]
+          risk_hint:
+            type: string
+            enum: [low, medium, high, critical]
+          lines_changed:
+            type: integer
+          rationale:
+            type: string
+    findings:
+      type: array
+      items:
+        type: object
+        properties:
+          id:
+            type: string
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+          kind:
+            type: string
+          path:
+            type: string
+          description:
+            type: string
+          evidence_ref:
+            type: string
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+    metadata:
+      type: object
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true
+
+normalization:
+  ref: "pilot/skills/_base/normalization.yaml"

--- a/pilot/skills/evidence-pack/prompt.md
+++ b/pilot/skills/evidence-pack/prompt.md
@@ -1,0 +1,88 @@
+# evidence-pack
+
+**Category:** collection
+**Contract:** `pilot/skills/_base/contract.yaml`
+**Schema:** `pilot/skills/evidence-pack/skill.yaml`
+
+## Purpose
+
+Collect, normalize, and validate all security evidence needed for a release gate or audit event. Produce a structured pack that an agent can use to determine whether sufficient evidence exists to proceed, and that an auditor can inspect to understand what was checked.
+
+## Execution Instructions
+
+1. **Determine required evidence types.** Use `constraints.required_evidence` if provided. If not, collect all available evidence types:
+   - `secrets-scan` — gitleaks or equivalent output
+   - `iac-scan` — checkov or equivalent output
+   - `dep-scan` — osv or equivalent output
+   - `sast-scan` — semgrep or equivalent output
+   - `diff-analysis` — diff-analysis skill output
+   - `threat-model` — threat-modeling skill output
+   - `policy-eval` — policy-eval skill output
+   - `sbom` — software bill of materials
+   - `test-results` — test run results
+
+2. **Locate evidence.** Search in `artifacts` paths and standard locations:
+   - `.pilot-sec/reports/`
+   - `.pilot-sec/runs/`
+   - Provided artifact paths
+
+3. **For each piece of evidence:**
+   - Verify it exists and is readable
+   - Check freshness (prefer evidence generated in the same run or within 24h)
+   - Extract: kind, source path, decision/status, findings count by severity
+   - Mark as `present`, `missing`, `stale`, or `invalid`
+
+4. **Identify missing evidence.** Compare collected evidence against `constraints.required_evidence`. List any missing kinds.
+
+5. **Emit output.** The pack is `complete` when all required evidence is `present` and none is `stale`.
+
+## Output Contract
+
+```yaml
+skill: "evidence-pack"
+status: partial
+summary: "5 of 6 required evidence types collected. SBOM is missing. Policy decision: warn."
+evidence:
+  - id: "ev-001"
+    kind: "secrets-scan"
+    source: ".pilot-sec/reports/gitleaks.json"
+    status: present
+    collected_at: "2026-03-20T14:23:00Z"
+    summary: "No secrets detected"
+    decision: "allow"
+    findings_count:
+      critical: 0
+      high: 0
+      medium: 0
+      low: 0
+  - id: "ev-002"
+    kind: "iac-scan"
+    source: ".pilot-sec/reports/checkov.json"
+    status: present
+    collected_at: "2026-03-20T14:25:00Z"
+    summary: "2 high findings in infra/s3.tf"
+    decision: "warn"
+    findings_count:
+      critical: 0
+      high: 2
+      medium: 1
+      low: 3
+missing_evidence:
+  - "sbom"
+artifacts_used:
+  - ".pilot-sec/reports/gitleaks.json"
+  - ".pilot-sec/reports/checkov.json"
+confidence: "high"
+metadata:
+  audit_target: "release-v1.2.0"
+  pack_complete: false
+  generated_at: "2026-03-20T14:30:00Z"
+```
+
+## Constraints
+
+- Do not run scans. Collect existing evidence only.
+- Do not modify any files.
+- Mark evidence `stale` if its `collected_at` is more than 24 hours before the current request.
+- A partial pack is still valid output — emit `status: partial` and list `missing_evidence`.
+- If all required evidence is missing, emit `status: failed`.

--- a/pilot/skills/evidence-pack/skill.yaml
+++ b/pilot/skills/evidence-pack/skill.yaml
@@ -1,0 +1,145 @@
+skill_contract_version: "0.1"
+
+skill:
+  id: "evidence-pack"
+  category: "collection"
+  version: "0.1"
+  description: "Collect and normalize evidence for release or audit"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 120
+  max_tool_calls: 8
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist:
+      - "git log"
+      - "git show"
+      - "git diff"
+      - "git describe"
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Report dirs, scan outputs, skill results to aggregate"
+    constraints:
+      type: object
+      properties:
+        required_evidence:
+          type: array
+          items:
+            type: string
+          description: "Evidence types that must be present (e.g. secrets-scan, iac-scan, sbom)"
+        audit_target:
+          type: string
+          description: "What this pack is evidence for (e.g. release-v1.2.0, PR-456)"
+    context:
+      type: object
+      properties:
+        environment:
+          type: string
+        actor:
+          type: string
+        timestamp:
+          type: string
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - evidence
+    - missing_evidence
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      enum: ["evidence-pack"]
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    evidence:
+      type: array
+      items:
+        type: object
+        required: [id, kind, source, status]
+        properties:
+          id:
+            type: string
+          kind:
+            type: string
+            description: "secrets-scan | iac-scan | dep-scan | sast-scan | diff-analysis | threat-model | policy-eval | sbom | test-results"
+          source:
+            type: string
+            description: "File path or skill output ref"
+          status:
+            type: string
+            enum: [present, missing, stale, invalid]
+          collected_at:
+            type: string
+          summary:
+            type: string
+          decision:
+            type: string
+            enum: [allow, warn, block, investigate]
+          findings_count:
+            type: object
+            properties:
+              critical: { type: integer }
+              high: { type: integer }
+              medium: { type: integer }
+              low: { type: integer }
+    missing_evidence:
+      type: array
+      items:
+        type: string
+      description: "Evidence kinds required but not found"
+    findings:
+      type: array
+      items:
+        type: object
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+    metadata:
+      type: object
+      properties:
+        audit_target:
+          type: string
+        pack_complete:
+          type: boolean
+        generated_at:
+          type: string
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true
+
+normalization:
+  ref: "pilot/skills/_base/normalization.yaml"

--- a/pilot/skills/iac-analysis/prompt.md
+++ b/pilot/skills/iac-analysis/prompt.md
@@ -1,0 +1,73 @@
+# iac-analysis
+
+**Category:** analysis
+**Contract:** `pilot/skills/_base/contract.yaml`
+**Schema:** `pilot/skills/iac-analysis/skill.yaml`
+
+## Purpose
+
+Analyze infrastructure-as-code files (Terraform, Kubernetes, CloudFormation, etc.) for security misconfigurations. Consume existing scanner reports when available; fall back to reading IaC files directly and applying pattern analysis.
+
+## Execution Instructions
+
+1. **Load inputs.** Check `artifacts` for checkov, tfsec, or kube-score JSON reports. If none, use `Glob` to find IaC files in `scope`:
+   - `*.tf`, `*.tfvars` (Terraform)
+   - `*.yaml`, `*.yml` in k8s paths (Kubernetes)
+   - `*-template.json`, `*.cfn.yaml` (CloudFormation)
+
+2. **Parse scan reports.** For each finding:
+   - Extract `rule_id`, `resource_kind`, `resource_name`, `path`, `line`
+   - Map severity using `normalization.yaml`
+   - Classify `misconfiguration_type`
+   - Extract or derive `remediation` steps
+
+3. **If reading IaC directly**, look for:
+   - Public ACLs or bucket policies (`public-exposure`)
+   - Missing encryption at rest or in transit (`missing-encryption`)
+   - Overly permissive IAM (`excessive-permissions`, e.g. `*:*`)
+   - Open security groups (0.0.0.0/0 ingress on sensitive ports)
+   - Missing logging or audit trails (`missing-logging`)
+   - Insecure defaults (HTTP instead of HTTPS, no TLS)
+   - Privileged containers or `runAsRoot` in Kubernetes
+
+4. **Identify exposure risks.** For public-facing resources, note the exposure type and severity.
+
+5. **Emit output.** Produce a valid output matching the schema.
+
+## Output Contract
+
+```yaml
+skill: "iac-analysis"
+status: success
+summary: "4 findings: 1 critical (public S3 bucket), 2 high (overpermissive IAM, missing encryption), 1 medium."
+findings:
+  - id: "iac-001"
+    severity: "critical"
+    rule_id: "CKV_AWS_20"
+    resource_kind: "aws_s3_bucket"
+    resource_name: "public_assets"
+    path: "infra/s3.tf"
+    line: 12
+    description: "S3 bucket allows public read access via ACL"
+    misconfiguration_type: "public-exposure"
+    remediation:
+      - "Remove acl = \"public-read\""
+      - "Add aws_s3_bucket_public_access_block resource"
+      - "Restrict bucket policy to specific principals"
+    evidence_ref: ".pilot-sec/reports/checkov.json#CKV_AWS_20"
+exposure_risks:
+  - resource: "aws_s3_bucket.public_assets"
+    exposure_type: "public-read"
+    severity: "critical"
+artifacts_used:
+  - ".pilot-sec/reports/checkov.json"
+confidence: "high"
+```
+
+## Constraints
+
+- Do not run IaC tools or plan/apply infrastructure.
+- Do not make policy decisions; emit findings only.
+- Filter to `constraints.severity_filter` when provided.
+- Focus on `constraints.frameworks` when specified.
+- If `constraints.changed_only` is true and diff context is available, prioritize changed IaC files.

--- a/pilot/skills/iac-analysis/skill.yaml
+++ b/pilot/skills/iac-analysis/skill.yaml
@@ -1,0 +1,136 @@
+skill_contract_version: "0.1"
+
+skill:
+  id: "iac-analysis"
+  category: "analysis"
+  version: "0.1"
+  description: "Analyze infrastructure-as-code for security misconfigurations"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 180
+  max_tool_calls: 10
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist:
+      - "git diff"
+      - "git show"
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+      description: "IaC file paths or directories (terraform, k8s, cloudformation, etc.)"
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Checkov/tfsec/kube-score reports, IaC files"
+    constraints:
+      type: object
+      properties:
+        severity_filter:
+          type: string
+          enum: [low, medium, high, critical]
+        frameworks:
+          type: array
+          items:
+            type: string
+          description: "terraform | kubernetes | cloudformation | arm | bicep"
+        changed_only:
+          type: boolean
+          default: true
+    context:
+      type: object
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - findings
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      enum: ["iac-analysis"]
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    findings:
+      type: array
+      items:
+        type: object
+        required: [id, severity, rule_id, resource_kind, resource_name, path, description]
+        properties:
+          id:
+            type: string
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+          rule_id:
+            type: string
+            description: "Checkov/tfsec rule ID (e.g. CKV_AWS_20)"
+          resource_kind:
+            type: string
+            description: "aws_s3_bucket | Deployment | SecurityGroup | etc."
+          resource_name:
+            type: string
+          path:
+            type: string
+          line:
+            type: integer
+          description:
+            type: string
+          misconfiguration_type:
+            type: string
+            description: "public-exposure | excessive-permissions | missing-encryption | missing-logging | missing-tls | insecure-default"
+          remediation:
+            type: array
+            items:
+              type: string
+          evidence_ref:
+            type: string
+    exposure_risks:
+      type: array
+      items:
+        type: object
+        properties:
+          resource:
+            type: string
+          exposure_type:
+            type: string
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true
+
+normalization:
+  ref: "pilot/skills/_base/normalization.yaml"

--- a/pilot/skills/incident-triage/prompt.md
+++ b/pilot/skills/incident-triage/prompt.md
@@ -1,0 +1,92 @@
+# incident-triage
+
+**Category:** analysis
+**Contract:** `pilot/skills/_base/contract.yaml`
+**Schema:** `pilot/skills/incident-triage/skill.yaml`
+
+## Purpose
+
+Triage one or more security signals into a structured incident assessment. Correlate related signals, determine overall severity, and produce a prioritized response action list. This skill does not take remediation actions — it produces triage structure for human or agent response.
+
+## Execution Instructions
+
+1. **Load inputs.** Read all provided `artifacts`: alert data, scan findings, skill outputs (secret-hygiene, iac-analysis, dep-analysis, diff-analysis), log excerpts.
+
+2. **Enumerate signals.** For each distinct security signal:
+   - Assign `id` (e.g. `sig-001`)
+   - Classify `kind`: `secret-exposure`, `vulnerability`, `misconfiguration`, `anomaly`, `policy-violation`, `supply-chain`
+   - Assign `severity` using normalization vocabulary
+   - Note `source` (file, report, or skill output ref)
+   - Set `likely_false_positive: true` if the signal matches a test fixture, placeholder, or known-safe pattern
+
+3. **Correlate signals.** Identify related signals that describe the same underlying issue:
+   - A secret in code + a CI pipeline with network access = correlated
+   - A public bucket + a vulnerability in the app that reads from it = correlated
+   - Add `correlated_signals` refs
+
+4. **Determine overall severity.** Set `severity` to the highest non-false-positive signal severity.
+
+5. **Generate response actions.** For each action needed:
+   - Assign `priority` (1 = most urgent)
+   - Write a specific, actionable `action` statement
+   - Assign `owner` (security-team, developer, infra-team, etc.)
+   - Set `urgency`: `immediate` (now), `hours` (same day), `days` (this week), `sprint` (this iteration)
+
+6. **Set `escalate`.** True if any signal is critical and likely_live, or if correlated signals create a combined critical risk.
+
+7. **Emit output.** Produce a valid output matching the schema.
+
+## Output Contract
+
+```yaml
+skill: "incident-triage"
+status: success
+summary: "Critical: live AWS key exposed in source + CI has network access. Immediate rotation and pipeline freeze required."
+severity: "critical"
+escalate: true
+signals:
+  - id: "sig-001"
+    kind: "secret-exposure"
+    severity: "critical"
+    description: "AWS access key (AKIA...) found in src/config.ts, committed 3 days ago; pattern matches live key format"
+    source: ".pilot-sec/reports/gitleaks.json"
+    correlated_signals: ["sig-002"]
+    likely_false_positive: false
+  - id: "sig-002"
+    kind: "misconfiguration"
+    severity: "high"
+    description: "CI workflow has unrestricted outbound network access, increasing blast radius of key exposure"
+    source: ".github/workflows/deploy.yml"
+    correlated_signals: ["sig-001"]
+    likely_false_positive: false
+response_actions:
+  - priority: 1
+    action: "Revoke AWS access key immediately via IAM console"
+    owner: "security-team"
+    urgency: "immediate"
+    rationale: "Key is likely live and CI has network access; any CI run may have exfiltrated or misused credentials"
+  - priority: 2
+    action: "Freeze all CI pipelines that reference the compromised key"
+    owner: "infra-team"
+    urgency: "immediate"
+  - priority: 3
+    action: "Audit CloudTrail for key usage over the past 7 days"
+    owner: "security-team"
+    urgency: "hours"
+  - priority: 4
+    action: "Remove key from git history using git-filter-repo and force-push"
+    owner: "developer"
+    urgency: "hours"
+artifacts_used:
+  - ".pilot-sec/reports/gitleaks.json"
+  - ".github/workflows/deploy.yml"
+confidence: "high"
+```
+
+## Constraints
+
+- Do not take remediation actions.
+- Mark `likely_false_positive: true` explicitly when applicable — do not silently drop signals.
+- Correlation is additive — correlated signals may increase overall severity beyond any individual signal.
+- Response actions must be specific, not generic. "Rotate credentials" is insufficient — specify what and where.
+- Set `escalate: true` conservatively; reserve it for situations requiring immediate human judgment.

--- a/pilot/skills/incident-triage/skill.yaml
+++ b/pilot/skills/incident-triage/skill.yaml
@@ -1,0 +1,151 @@
+skill_contract_version: "0.1"
+
+skill:
+  id: "incident-triage"
+  category: "analysis"
+  version: "0.1"
+  description: "Triage security signals into structured incident reports with prioritized response actions"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 120
+  max_tool_calls: 8
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist:
+      - "git log"
+      - "git show"
+      - "git diff"
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Alert data, scan findings, skill outputs, log excerpts"
+    constraints:
+      type: object
+      properties:
+        severity_filter:
+          type: string
+          enum: [low, medium, high, critical]
+        time_window:
+          type: string
+          description: "ISO 8601 interval (e.g. PT24H for last 24 hours)"
+    context:
+      type: object
+      properties:
+        environment:
+          type: string
+        actor:
+          type: string
+        trigger:
+          type: string
+          description: "What initiated this triage (alert | scan | manual | pr)"
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - severity
+    - signals
+    - response_actions
+    - findings
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      enum: ["incident-triage"]
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    severity:
+      type: string
+      enum: [low, medium, high, critical]
+      description: "Overall triage severity — highest signal severity"
+    signals:
+      type: array
+      items:
+        type: object
+        required: [id, kind, severity, description, source]
+        properties:
+          id:
+            type: string
+          kind:
+            type: string
+            description: "secret-exposure | vulnerability | misconfiguration | anomaly | policy-violation | supply-chain"
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+          description:
+            type: string
+          source:
+            type: string
+          correlated_signals:
+            type: array
+            items:
+              type: string
+            description: "IDs of related signals"
+          likely_false_positive:
+            type: boolean
+    response_actions:
+      type: array
+      items:
+        type: object
+        required: [priority, action, owner, urgency]
+        properties:
+          priority:
+            type: integer
+            minimum: 1
+          action:
+            type: string
+          owner:
+            type: string
+            description: "Team or role responsible"
+          urgency:
+            type: string
+            enum: [immediate | hours | days | sprint]
+          rationale:
+            type: string
+    escalate:
+      type: boolean
+      description: "Whether this requires immediate human escalation"
+    findings:
+      type: array
+      items:
+        type: object
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true
+
+normalization:
+  ref: "pilot/skills/_base/normalization.yaml"

--- a/pilot/skills/policy-eval/prompt.md
+++ b/pilot/skills/policy-eval/prompt.md
@@ -1,0 +1,81 @@
+# policy-eval
+
+**Category:** evaluation
+**Contract:** `pilot/skills/_base/contract.yaml`
+**Schema:** `pilot/skills/policy-eval/skill.yaml`
+
+## Purpose
+
+Evaluate normalized evidence (findings from other skills, scan outputs) against policy rules and emit a structured decision. The decision is one of: `allow`, `warn`, `block`, `investigate`.
+
+Policy evaluation is deterministic given the same facts and rules. This skill should not perform new discovery — it consumes evidence already collected.
+
+## Execution Instructions
+
+1. **Load policy packs.** Read the rule files listed in `policy_context.packs`. Also read `policy_context.waivers_file` if provided. Use `Read` and `Glob` to locate rule YAML files under `pilot/policy/`.
+
+2. **Normalize incoming facts.** Parse all artifacts (skill output JSON/YAML, finding files). Extract the fact model fields needed for rule evaluation:
+   - `finding.type`, `finding.severity`, `finding.path`
+   - `policy.context.environment`, `git.branch`, `session.actor`
+   - Any additional facts referenced by rules
+
+3. **Evaluate rules.** For each rule in the loaded packs:
+   - Check `applies_to.events` and `applies_to.targets` — skip rules that don't apply
+   - Evaluate the `match` conditions using the fact model
+   - Check if a valid, non-expired waiver covers this rule+scope combination
+   - Classify the outcome: passed, failed-and-blocked, failed-and-warned, waived
+
+4. **Determine overall decision.** Apply this logic:
+   - Any rule with `effect: block` and no covering waiver → `decision: block`
+   - Any rule with `effect: warn` and no covering waiver → `decision: warn` (if no block)
+   - All rules pass or waived → `decision: allow`
+   - Insufficient evidence to evaluate → `decision: investigate`
+   - In `observe` mode: never emit `block`, emit `warn` instead
+
+5. **Emit output.** Produce a valid output matching the schema.
+
+## Output Contract
+
+```yaml
+skill: "policy-eval"
+status: success
+summary: "2 rules failed. 1 blocking (public storage in staging). 1 waived (dev public assets). Decision: block."
+decision: "block"
+failed_rules:
+  - rule_id: "no-public-storage"
+    title: "Disallow public object storage"
+    severity: "high"
+    effect: "block"
+    finding_ref: ".pilot-sec/reports/checkov.json#CKV_AWS_20"
+    message: "Public buckets are not allowed in staging"
+    remediation:
+      - "Set public_access_block = true"
+      - "Restrict bucket policy principals"
+waivers_applied:
+  - waiver_id: "waiver-001"
+    rule_id: "no-public-storage"
+    scope:
+      paths: ["infra/dev/public-assets.tf"]
+      environments: ["dev"]
+    approved_by: "esteban"
+    expires_at: "2026-06-30T00:00:00Z"
+    reason: "Temporary public asset hosting during migration"
+passed_rules:
+  - "no-hardcoded-secrets"
+  - "require-tls-1.3"
+artifacts_used:
+  - ".pilot-sec/reports/checkov.json"
+  - "pilot/policy/policies/devsecops/rules/no-public-storage.yaml"
+confidence: "high"
+```
+
+## Constraints
+
+- Do not discover new findings. Consume only provided artifacts.
+- Respect `policy_context.mode`:
+  - `observe`: evaluate but never emit `block`
+  - `warn`: evaluate but never emit `block`
+  - `enforce`: emit `block` when required
+- Respect `policy_context.fail_on`: only block on findings at or above this severity.
+- Expired waivers do not count. Check `expires_at` against current date.
+- If a rule references a fact not present in the evidence, skip that rule and note it in `errors`.

--- a/pilot/skills/policy-eval/skill.yaml
+++ b/pilot/skills/policy-eval/skill.yaml
@@ -1,0 +1,158 @@
+skill_contract_version: "0.1"
+
+skill:
+  id: "policy-eval"
+  category: "evaluation"
+  version: "0.1"
+  description: "Map evidence to policy decisions using structured rule evaluation"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 60
+  max_tool_calls: 4
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+  bash_constraints:
+    deny_destructive: true
+    allowlist: []
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - artifacts
+    - policy_context
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Normalized findings, skill outputs, scan reports"
+    policy_context:
+      type: object
+      required:
+        - environment
+        - branch
+      properties:
+        environment:
+          type: string
+          description: "dev | staging | prod"
+        branch:
+          type: string
+        actor:
+          type: string
+        packs:
+          type: array
+          items:
+            type: string
+          description: "Policy pack paths to evaluate against"
+        waivers_file:
+          type: string
+        mode:
+          type: string
+          enum: [observe, warn, enforce]
+          default: "enforce"
+        fail_on:
+          type: string
+          enum: [low, medium, high, critical]
+          default: "high"
+    constraints:
+      type: object
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - decision
+    - failed_rules
+    - waivers_applied
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      enum: ["policy-eval"]
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    decision:
+      type: string
+      enum: [allow, warn, block, investigate]
+    failed_rules:
+      type: array
+      items:
+        type: object
+        required: [rule_id, title, severity, effect, finding_ref]
+        properties:
+          rule_id:
+            type: string
+          title:
+            type: string
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+          effect:
+            type: string
+            enum: [allow, warn, block]
+          finding_ref:
+            type: string
+          message:
+            type: string
+          remediation:
+            type: array
+            items:
+              type: string
+    waivers_applied:
+      type: array
+      items:
+        type: object
+        required: [waiver_id, rule_id, scope, approved_by]
+        properties:
+          waiver_id:
+            type: string
+          rule_id:
+            type: string
+          scope:
+            type: object
+          approved_by:
+            type: string
+          expires_at:
+            type: string
+          reason:
+            type: string
+    passed_rules:
+      type: array
+      items:
+        type: string
+      description: "Rule IDs that were evaluated and passed"
+    findings:
+      type: array
+      items:
+        type: object
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+    metadata:
+      type: object
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true
+
+normalization:
+  ref: "pilot/skills/_base/normalization.yaml"

--- a/pilot/skills/secret-hygiene/prompt.md
+++ b/pilot/skills/secret-hygiene/prompt.md
@@ -1,0 +1,75 @@
+# secret-hygiene
+
+**Category:** analysis
+**Contract:** `pilot/skills/_base/contract.yaml`
+**Schema:** `pilot/skills/secret-hygiene/skill.yaml`
+
+## Purpose
+
+Detect, classify, and assess the exposure of secrets in source code, diffs, or scan reports. Produce a structured finding set and an exposure assessment with concrete revocation guidance. Always redact actual secret values in output.
+
+## Execution Instructions
+
+1. **Load inputs.** Read scan reports (gitleaks JSON, semgrep output) from `artifacts`. If no pre-existing reports, use `Grep` to scan `scope` paths for secret patterns.
+
+2. **For each detected secret:**
+   - Classify `kind`: `api-key`, `token`, `password`, `certificate`, `private-key`, `connection-string`, `generic`
+   - Assign `severity`:
+     - `critical`: private keys, production credentials, cloud IAM keys
+     - `high`: API keys, tokens with broad scope
+     - `medium`: test credentials, limited-scope tokens
+     - `low`: placeholder values, example patterns
+   - Record `path` and `line`
+   - Set `redacted: true` — never include the actual value in output
+   - Set `likely_valid: true` if the value pattern matches a known live format (not a test/example)
+
+3. **Assess exposure.** For the full finding set:
+   - `likely_live`: true if any finding has `likely_valid: true`
+   - `locations`: where each secret appears (`current code`, `git history`, `PR diff`)
+   - `blast_radius`: worst-case scope of compromise
+   - `revoke_guidance`: ordered steps — rotate first, then audit, then close gaps
+   - `notify_required`: true if likely_live and severity >= high
+
+4. **Emit output.** Produce a valid output matching the schema.
+
+## Output Contract
+
+```yaml
+skill: "secret-hygiene"
+status: success
+summary: "1 critical finding: likely-live AWS access key in src/config.ts. Immediate rotation required."
+findings:
+  - id: "sh-001"
+    severity: "critical"
+    kind: "api-key"
+    path: "src/config.ts"
+    line: 42
+    description: "AWS access key pattern detected (AKIA...); value redacted"
+    redacted: true
+    evidence_ref: ".pilot-sec/reports/gitleaks.json#rule-aws-access-key"
+    likely_valid: true
+exposure_assessment:
+  likely_live: true
+  locations:
+    - "current code"
+    - "git history (3 commits)"
+  revoke_guidance:
+    - "Immediately revoke the AWS access key in IAM console"
+    - "Audit CloudTrail for usage since first commit date"
+    - "Rotate all secrets that share the same IAM user"
+    - "Remove from git history using git-filter-repo"
+    - "Add pre-commit secret scanning hook"
+  notify_required: true
+  blast_radius: "critical"
+artifacts_used:
+  - ".pilot-sec/reports/gitleaks.json"
+confidence: "high"
+```
+
+## Constraints
+
+- Never emit actual secret values. Always set `redacted: true` and omit the value.
+- If `constraints.include_git_history` is true, check git log for secrets removed from HEAD but present in history.
+- `likely_valid` is a best-effort assessment based on format patterns, not live API validation.
+- Emit `status: partial` if some artifact files were unreadable.
+- Revoke guidance should always be specific and ordered — not generic advice.

--- a/pilot/skills/secret-hygiene/skill.yaml
+++ b/pilot/skills/secret-hygiene/skill.yaml
@@ -1,0 +1,142 @@
+skill_contract_version: "0.1"
+
+skill:
+  id: "secret-hygiene"
+  category: "analysis"
+  version: "0.1"
+  description: "Detect, classify, redact, and advise on response for exposed secrets"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 120
+  max_tool_calls: 8
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist:
+      - "git diff"
+      - "git log"
+      - "git show"
+      - "git ls-files"
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Scan reports, diff files, source paths"
+    constraints:
+      type: object
+      properties:
+        severity_filter:
+          type: string
+          enum: [low, medium, high, critical]
+        include_git_history:
+          type: boolean
+          default: false
+    context:
+      type: object
+      properties:
+        base_ref:
+          type: string
+        head_ref:
+          type: string
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - findings
+    - exposure_assessment
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      enum: ["secret-hygiene"]
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    findings:
+      type: array
+      items:
+        type: object
+        required: [id, severity, kind, path, description, redacted]
+        properties:
+          id:
+            type: string
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+          kind:
+            type: string
+            description: "api-key | token | password | certificate | private-key | connection-string | generic"
+          path:
+            type: string
+          line:
+            type: integer
+          description:
+            type: string
+          redacted:
+            type: boolean
+            description: "True if the value has been redacted in this output"
+          evidence_ref:
+            type: string
+          likely_valid:
+            type: boolean
+    exposure_assessment:
+      type: object
+      required: [likely_live, locations, revoke_guidance]
+      properties:
+        likely_live:
+          type: boolean
+          description: "Whether any detected secret is likely still valid/active"
+        locations:
+          type: array
+          items:
+            type: string
+          description: "Where the secret was found (current code | git history | PR diff)"
+        revoke_guidance:
+          type: array
+          items:
+            type: string
+          description: "Ordered steps to revoke and rotate"
+        notify_required:
+          type: boolean
+          description: "Whether security team notification is warranted"
+        blast_radius:
+          type: string
+          enum: [low, medium, high, critical]
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true
+
+normalization:
+  ref: "pilot/skills/_base/normalization.yaml"

--- a/pilot/skills/threat-modeling/prompt.md
+++ b/pilot/skills/threat-modeling/prompt.md
@@ -1,0 +1,83 @@
+# threat-modeling
+
+**Category:** analysis
+**Contract:** `pilot/skills/_base/contract.yaml`
+**Schema:** `pilot/skills/threat-modeling/skill.yaml`
+
+## Purpose
+
+Identify the security-relevant structure of the system or change under review: what assets exist, where trust boundaries are drawn, what entry points are exposed, and what abuse cases are plausible. This skill feeds agents that must reason about risk without repeating discovery work.
+
+This skill does not emit policy decisions. It produces threat structure that agents and policy-eval consume.
+
+## Execution Instructions
+
+1. **Read the artifacts.** Examine source files, IaC, architecture docs, API specs, or the `context.changed_surfaces` list from a prior diff-analysis run.
+
+2. **Identify assets.** For each meaningful data store, secret, identity, or capability:
+   - Assign an `id` (e.g. `asset-001`)
+   - Name it clearly
+   - Rate `sensitivity` using: `low`, `medium`, `high`, `critical`
+
+3. **Map trust boundaries.** For each interface where trust level changes (user→API, API→DB, service→cloud provider, CI→prod):
+   - Identify the `from` and `to` zones
+   - Note existing `controls` (auth, TLS, network policy, etc.)
+
+4. **Enumerate entry points.** For each place where external input enters the system:
+   - Classify by `kind`: `api`, `ui`, `file`, `network`, `event`, `cli`, `webhook`, `auth`
+   - Assign `risk_hint` based on exposure and input handling quality
+
+5. **Derive abuse cases.** For each plausible attacker path:
+   - Identify `threat_actor` (e.g. unauthenticated user, malicious dependency, insider)
+   - Trace `entry_point` → `asset`
+   - Describe `attack_path` in one sentence
+   - Assign `severity`
+   - Suggest `mitigations`
+
+6. **Emit output.** Produce a valid output matching the schema.
+
+## Output Contract
+
+```yaml
+skill: "threat-modeling"
+status: success | partial | failed
+summary: "<paragraph>"
+assets:
+  - id: "asset-001"
+    name: "User credential store"
+    sensitivity: "critical"
+    description: "Bcrypt-hashed passwords in PostgreSQL users table"
+trust_boundaries:
+  - id: "tb-001"
+    name: "Public internet → API gateway"
+    from: "internet"
+    to: "api-gateway"
+    controls: ["TLS 1.3", "rate limiting", "WAF"]
+entry_points:
+  - id: "ep-001"
+    name: "POST /api/auth/login"
+    kind: "api"
+    risk_hint: "critical"
+    description: "Accepts username/password; issues JWT"
+abuse_cases:
+  - id: "abuse-001"
+    title: "Credential stuffing via login endpoint"
+    threat_actor: "unauthenticated external attacker"
+    entry_point: "ep-001"
+    asset: "asset-001"
+    attack_path: "Attacker submits bulk credential pairs to /api/auth/login to enumerate valid accounts"
+    severity: "high"
+    mitigations:
+      - "Implement account lockout after N failures"
+      - "Add CAPTCHA on repeated failure"
+artifacts_used:
+  - "src/auth/routes.ts"
+confidence: "medium"
+```
+
+## Constraints
+
+- Do not make policy decisions.
+- If `context.changed_surfaces` is provided, prioritize threat-modeling the changed surfaces first.
+- Scope to `constraints.focus` categories when provided.
+- Emit `status: partial` if you can model some but not all entry points due to missing artifacts.

--- a/pilot/skills/threat-modeling/skill.yaml
+++ b/pilot/skills/threat-modeling/skill.yaml
@@ -1,0 +1,176 @@
+skill_contract_version: "0.1"
+
+skill:
+  id: "threat-modeling"
+  category: "analysis"
+  version: "0.1"
+  description: "Identify assets, trust boundaries, entry points, and abuse cases"
+
+execution:
+  mode: "read-only"
+  timeout_seconds: 180
+  max_tool_calls: 10
+  allowed_tools:
+    - Read
+    - Grep
+    - Glob
+    - Bash
+  bash_constraints:
+    deny_destructive: true
+    allowlist:
+      - "git diff"
+      - "git show"
+      - "git log"
+
+input_schema:
+  type: object
+  required:
+    - objective
+    - scope
+    - artifacts
+  properties:
+    objective:
+      type: string
+    scope:
+      type: array
+      items:
+        type: string
+    artifacts:
+      type: array
+      items:
+        type: string
+      description: "Source files, architecture docs, IaC, API specs, changed files list"
+    constraints:
+      type: object
+      properties:
+        focus:
+          type: array
+          items:
+            type: string
+          description: "Constrain to specific threat categories (e.g. injection, privilege-escalation)"
+        changed_only:
+          type: boolean
+          default: false
+    context:
+      type: object
+      properties:
+        environment:
+          type: string
+        changed_surfaces:
+          type: array
+          description: "Output from diff-analysis skill, if available"
+
+output_schema:
+  type: object
+  required:
+    - skill
+    - status
+    - summary
+    - assets
+    - trust_boundaries
+    - entry_points
+    - abuse_cases
+    - artifacts_used
+  properties:
+    skill:
+      type: string
+      enum: ["threat-modeling"]
+    status:
+      type: string
+      enum: [success, partial, failed]
+    summary:
+      type: string
+    assets:
+      type: array
+      items:
+        type: object
+        required: [id, name, sensitivity]
+        properties:
+          id:
+            type: string
+          name:
+            type: string
+          sensitivity:
+            type: string
+            enum: [low, medium, high, critical]
+          description:
+            type: string
+    trust_boundaries:
+      type: array
+      items:
+        type: object
+        required: [id, name, from, to]
+        properties:
+          id:
+            type: string
+          name:
+            type: string
+          from:
+            type: string
+          to:
+            type: string
+          controls:
+            type: array
+            items:
+              type: string
+    entry_points:
+      type: array
+      items:
+        type: object
+        required: [id, name, kind, risk_hint]
+        properties:
+          id:
+            type: string
+          name:
+            type: string
+          kind:
+            type: string
+            enum: [api, ui, file, network, event, cli, webhook, auth]
+          risk_hint:
+            type: string
+            enum: [low, medium, high, critical]
+          description:
+            type: string
+    abuse_cases:
+      type: array
+      items:
+        type: object
+        required: [id, title, threat_actor, entry_point, asset, severity]
+        properties:
+          id:
+            type: string
+          title:
+            type: string
+          threat_actor:
+            type: string
+          entry_point:
+            type: string
+          asset:
+            type: string
+          attack_path:
+            type: string
+          severity:
+            type: string
+            enum: [low, medium, high, critical]
+          mitigations:
+            type: array
+            items:
+              type: string
+    findings:
+      type: array
+      items:
+        type: object
+    artifacts_used:
+      type: array
+      items:
+        type: string
+    confidence:
+      type: string
+      enum: [high, medium, low]
+
+failure_contract:
+  return_partial_on_error: true
+  include_errors: true
+
+normalization:
+  ref: "pilot/skills/_base/normalization.yaml"


### PR DESCRIPTION
## Summary

This PR introduces the foundational schema definitions and skill contracts that define the security scanning and policy evaluation pipeline. These schemas establish the contracts between scanner adapters, skills, the policy engine, and the broader system.

## Key Changes

**Core Schema Definitions:**
- `finding.schema.yaml` — Normalized finding record that all scanner adapters must emit (secrets, IaC, dependencies, SAST)
- `provider.schema.yaml` — Configuration schema for scanner providers (gitleaks, checkov, osv, semgrep, etc.) with per-provider argument specifications
- `normalization.yaml` — Shared vocabulary for severity, confidence, and decision scales across all skills
- `facts.schema.yaml` — Canonical fact model used by the policy engine; bridges scanners, agents, and policy rules

**Policy Engine Schemas:**
- `rule.schema.yaml` — Structure for policy rules with condition trees, match logic, and decision effects
- `waiver.schema.yaml` — Time-bounded, attributable exceptions to policy rules with scoped applicability

**Skill Contracts:**
- Base contract (`_base/contract.yaml`) — Inherited by all skills, defining execution constraints, tool allowlists, and I/O structure
- Analysis skills: `diff-analysis`, `threat-modeling`, `attack-surface`, `secret-hygiene`, `iac-analysis`, `dep-analysis`
- Evaluation skill: `policy-eval` — Maps evidence to policy decisions
- Triage skill: `incident-triage` — Correlates security signals into structured incident reports
- Collection skill: `evidence-pack` — Aggregates evidence for release gates and audits

**Skill Prompts:**
- Detailed execution instructions for each skill, defining how to process inputs, normalize findings, and structure outputs
- Consistent guidance on severity classification, confidence assessment, and remediation guidance

## Notable Implementation Details

- All scanner adapters normalize to `finding/v1` schema, ensuring downstream skills and policy rules operate on consistent data structures
- Skills are read-only by default with explicit bash allowlists; no skill calls agents (acyclic dependency graph)
- Policy rules evaluate against normalized facts, never raw tool output, enabling deterministic and auditable decisions
- Waivers are scoped (paths, environments, branches, actors) to prevent blanket exceptions
- Severity and confidence scales are unified across all tools via `normalization.yaml`
- Each skill declares its own execution constraints (timeout, tool calls, bash allowlist) within the base contract framework

https://claude.ai/code/session_01F7LRWsypDb4acuuMgBCF2K