### PR TITLE
fix(hooks): make SessionEnd fully non-blocking so harness cancellation can't leak workers

### DIFF
--- a/pilot/hooks/session_end.py
+++ b/pilot/hooks/session_end.py
@@ -3,15 +3,17 @@
 
 1. Marks the session as completed in the Console (so the sessions tab updates)
 2. Stops the worker only when the current session is the last active one
+
+Both side-effects are handed off to detached subprocesses so this hook never
+blocks on network or child-process I/O. Claude Code's harness may cancel the
+SessionEnd hook at any point; detaching guarantees the work still completes.
 """
 
 from __future__ import annotations
 
-import json
 import os
 import subprocess
 import sys
-import urllib.request
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
@@ -20,27 +22,52 @@ SESSIONS_DIR = Path.home() / ".pilot" / "sessions"
 SKIP_NAMES = {"default", "pipes"}
 CONSOLE_URL = "http://localhost:41777"
 
+# Inlined script run by the detached Console POST worker. Kept minimal so the
+# subprocess startup cost is the only overhead when Console is down.
+_COMPLETE_SESSION_WORKER = """
+import json, sys, urllib.request
+url, sid = sys.argv[1], sys.argv[2]
+req = urllib.request.Request(
+    url,
+    data=json.dumps({'contentSessionId': sid}).encode(),
+    headers={'Content-Type': 'application/json'},
+    method='POST',
+)
+try:
+    urllib.request.urlopen(req, timeout=5)
+except Exception:
+    pass
+"""
+
 
 def _complete_session() -> None:
     """Mark the current session as completed in the Console.
 
-    Fire-and-forget — silently ignores errors. The Console may already
-    be stopped or the session may not exist (e.g. private session).
+    Fully detached fire-and-forget. Spawns a short-lived Python subprocess
+    that does the POST so this hook never blocks on network I/O — the harness
+    can cancel the hook mid-flight and the notification still goes out in
+    its own process group. Errors inside the worker are swallowed.
     """
     session_id = os.environ.get("CLAUDE_SESSION_ID", "")
     if not session_id:
         return
 
-    payload = json.dumps({"contentSessionId": session_id}).encode()
-    req = urllib.request.Request(
-        f"{CONSOLE_URL}/api/sessions/complete",
-        data=payload,
-        headers={"Content-Type": "application/json"},
-        method="POST",
-    )
     try:
-        urllib.request.urlopen(req, timeout=5)
-    except Exception:
+        _ = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                _COMPLETE_SESSION_WORKER,
+                f"{CONSOLE_URL}/api/sessions/complete",
+                session_id,
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except OSError:
         pass
 
 
@@ -85,23 +112,25 @@ def main() -> int:
     if not plugin_root:
         return 0
 
-    # Mark session as completed in Console (fire-and-forget)
+    # Spawn the detached worker-stop BEFORE any network I/O so the critical
+    # side effect (releasing port 41777, closing SQLite WAL handles) survives
+    # even if the harness cancels this hook mid-flight.
+    if not _has_other_active_sessions():
+        stop_script = Path(plugin_root) / "scripts" / "worker-service.cjs"
+        try:
+            _ = subprocess.Popen(
+                ["bun", str(stop_script), "stop"],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+                close_fds=True,
+            )
+        except OSError:
+            pass
+
+    # Mark session as completed in Console (fully detached, never blocks)
     _complete_session()
-
-    if _has_other_active_sessions():
-        return 0
-
-    stop_script = Path(plugin_root) / "scripts" / "worker-service.cjs"
-    try:
-        subprocess.run(
-            ["bun", str(stop_script), "stop"],
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=15,
-        )
-    except subprocess.TimeoutExpired:
-        pass
 
     return 0
 


### PR DESCRIPTION
Fixes #129.

## Summary

The `SessionEnd` hook runs two side-effects synchronously:

1. `_complete_session` → `urllib.request.urlopen(..., timeout=5)` (Console POST)
2. `main` → `subprocess.run(["bun", ...], timeout=15)` (worker-stop)

Claude Code's harness cancels the hook after a short deadline. When it does, the hook process dies **before either side-effect completes**, so:

- Terminal shows `SessionEnd hook [...] failed: Hook cancelled`
- `bun worker-service.cjs --daemon` instances leak across sessions
- Orphans hold open file descriptors to `~/.pilot/memory/pilot-memory.db` (SQLite WAL) but serve no traffic (only the newest is bound to :41777)

## Fix

Both side-effects are now handed off to detached subprocesses (`start_new_session=True`) before `main` returns. The hook itself becomes near-instantaneous (two non-blocking `Popen` calls), so harness cancellation no longer races the work.

**Ordering:** worker-stop first, Console POST second. The worker-stop is the leakier side-effect (holds file descriptors + a network port); running it first means even a pathological failure of the second `Popen` still frees the critical resources.

**Timeouts preserved.** The inlined Console POST worker still uses `timeout=5`. The worker-stop previously had `timeout=15` on the synchronous `subprocess.run`; since it now runs in its own session (no parent to tie up), there's no deadline needed at the hook level. The bun script retains its own internal stop logic.

**Inlined worker script.** The Console POST logic is a small string constant (`_COMPLETE_SESSION_WORKER`) passed to `python -c`. This avoids adding a new file to the repo and keeps everything in one place. Subprocess startup cost (~30ms) is the only overhead when Console is down — negligible compared to the previous 5s hang.

## Verification

- `python -m py_compile pilot/hooks/session_end.py` → passes
- `main()` with no env vars returns 0 cleanly (short-circuits on missing `CLAUDE_PLUGIN_ROOT`)
- Inlined worker executes cleanly when invoked with live Console: `python3 -c <script> <url> <sid>` → `POST 200`
- Manual reproduction: observed 3 running daemons (2 orphaned) before the fix; after the fix, no orphans accumulate across repeated session start/stop cycles
- Data safety: workers are stateless HTTP fronts over shared SQLite-WAL; killing old leaked workers with SIGTERM left DB integrity intact (`PRAGMA integrity_check = ok`)

## Why not just raise the harness hook timeout?

The hook timeout lives on the Claude Code side, not in this repo. Even if raised, network stalls, bun startup latency, and fsync spikes on loaded disks can push a synchronous implementation past any fixed deadline. Detaching removes the entire class of failure.

## Scope

- Single file changed: `pilot/hooks/session_end.py`
- No API surface change, no new dependencies
- Diff: +58 / −29