### PR TITLE
fix(spec-stop-guard): ignore active plan outside current project

### DIFF
--- a/pilot/hooks/spec_stop_guard.py
+++ b/pilot/hooks/spec_stop_guard.py
@@ -25,6 +25,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 from _lib.util import (
     _sessions_base,
     build_objective_reinjection,
+    find_git_root,
     get_session_plan_path,
     is_waiting_for_user_input,
     stop_block,
@@ -67,6 +68,41 @@ def get_handoff_sentinel_path() -> Path:
     return guard_dir / "spec-handoff-pending"
 
 
+def _current_project_root() -> Path | None:
+    """Best-effort current project root: CLAUDE_PROJECT_ROOT, else git root, else cwd."""
+    root = os.environ.get("CLAUDE_PROJECT_ROOT", "").strip()
+    if root:
+        return Path(root)
+    git_root = find_git_root()
+    if git_root is not None:
+        return git_root
+    try:
+        return Path.cwd()
+    except OSError:
+        return None
+
+
+def _plan_in_current_project(plan_file: Path) -> bool:
+    """True if plan_file lives inside the current project root.
+
+    Cross-session bleed guard: when PILOT_SESSION_ID is unset, the session-scoped
+    active_plan.json collapses to the shared "default" file, so a /spec plan
+    registered by ANOTHER repo's session can block stops in an unrelated repo.
+    Only enforce the stop-guard for a plan that actually lives in the project this
+    session is running in. Fails open (returns True -> legacy behavior) when the
+    project root cannot be determined, so legitimate guarding is never weakened.
+    """
+    root = _current_project_root()
+    if root is None:
+        return True
+    try:
+        root_real = os.path.realpath(root)
+        plan_real = os.path.realpath(plan_file)
+        return os.path.commonpath([root_real, plan_real]) == root_real
+    except (ValueError, OSError):
+        return True
+
+
 def find_active_plan() -> tuple[Path | None, str | None]:
     """Find the active plan for THIS session via session-scoped active_plan.json."""
     plan_json = get_session_plan_path()
@@ -87,6 +123,12 @@ def find_active_plan() -> tuple[Path | None, str | None]:
         project_root = os.environ.get("CLAUDE_PROJECT_ROOT", str(Path.cwd()))
         plan_file = Path(project_root) / plan_file
     if not plan_file.exists():
+        return None, None
+
+    # Cross-session bleed guard: ignore an active plan that isn't part of this
+    # project (e.g. a COMPLETE plan from another repo's /spec session leaking in
+    # through the shared "default" active_plan.json when PILOT_SESSION_ID unset).
+    if not _plan_in_current_project(plan_file):
         return None, None
 
     try:

--- a/pilot/hooks/tests/test_spec_stop_guard.py
+++ b/pilot/hooks/tests/test_spec_stop_guard.py
@@ -707,6 +707,46 @@ class TestSessionScopedPlanDetection:
         assert _is_blocked(stdout)
         assert "cannot stop" in stdout.lower()
 
+    def test_ignores_plan_outside_current_project(self, tmp_path: Path) -> None:
+        """Cross-session bleed: a registered plan that lives OUTSIDE the current
+        project root must not block. Reproduces the failure where PILOT_SESSION_ID
+        is unset, active_plan.json collapses to the shared 'default' file, and a
+        /spec plan from another repo's session blocked stops in an unrelated repo.
+        """
+        project = tmp_path / "current-project"
+        plans_dir = project / "docs" / "plans"
+        plans_dir.mkdir(parents=True)
+
+        other_plans = tmp_path / "other-project" / "docs" / "plans"
+        other_plans.mkdir(parents=True)
+        foreign_plan = other_plans / "2026-02-06-foreign.md"
+        foreign_plan.write_text("# Foreign\n\nStatus: PENDING\nApproved: Yes\n")
+        _register_plan_for_session(foreign_plan, "PENDING")
+
+        with patch.dict(os.environ, {"CLAUDE_PROJECT_ROOT": str(project)}):
+            exit_code, stdout, _ = _run_subprocess({"stop_hook_active": False}, plans_dir)
+
+        assert exit_code == 0
+        assert not _is_blocked(stdout)
+
+    def test_blocks_absolute_plan_inside_current_project(self, tmp_path: Path) -> None:
+        """The project-scope guard must not over-suppress: an absolute plan path
+        INSIDE the current project root still blocks."""
+        project = tmp_path / "current-project"
+        plans_dir = project / "docs" / "plans"
+        plans_dir.mkdir(parents=True)
+
+        plan_file = plans_dir / "2026-02-06-in-project.md"
+        plan_file.write_text("# In Project\n\nStatus: PENDING\nApproved: No\n")
+        _register_plan_for_session(plan_file, "PENDING")
+
+        with patch.dict(os.environ, {"CLAUDE_PROJECT_ROOT": str(project)}):
+            exit_code, stdout, _ = _run_subprocess({"stop_hook_active": False}, plans_dir)
+
+        assert exit_code == 0
+        assert _is_blocked(stdout)
+        assert "cannot stop" in stdout.lower()
+
 
 class TestHandoffSentinel:
     """The model-switch handoff sentinel grants permission to stop while it lives.


### PR DESCRIPTION
## Problem

When `PILOT_SESSION_ID` is unset, the session-scoped `active_plan.json` collapses to the shared `default` file. A `/spec` plan registered by **another repo's** session then leaks into an unrelated repo's session through that shared file, and `spec_stop_guard.py` blocks stops on a plan that has nothing to do with the current project.

Observed: a `COMPLETE` plan in repo A blocked every stop in an unrelated repo B's session ("you cannot stop…"), with no clean way to clear it short of hand-editing the shared state.

## Fix

Scope the guard to plans that actually live inside the current project root:

- `_current_project_root()` resolves `CLAUDE_PROJECT_ROOT` → git root → cwd.
- `_plan_in_current_project()` returns `False` when the registered plan path is outside that root, so `find_active_plan()` returns `(None, None)` and the guard stays out of the way.
- **Fails open**: if the project root can't be determined it returns `True` (legacy behaviour), so legitimate same-project guarding is never weakened.

## Tests

Two new tests in `TestSessionScopedPlanDetection`:
- `test_ignores_plan_outside_current_project` — reproduces the bleed: a foreign-project plan must not block.
- `test_blocks_absolute_plan_inside_current_project` — guards against over-suppression: an absolute plan path inside the current project still blocks.

`42 passed` locally (`pytest pilot/hooks/tests/test_spec_stop_guard.py`).

## Notes

Additive and non-breaking — no change to behaviour when a single session/project is involved. Surfaced while running `/spec` in one repo with a stale `COMPLETE` plan registered from another.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented cross-session bleed in `spec_stop_guard` so a plan from another repo no longer blocks stops when `PILOT_SESSION_ID` is unset. The guard now only applies to plans inside the current project.

- **Bug Fixes**
  - Scope active plan checks to the current project root: `CLAUDE_PROJECT_ROOT` → git root → cwd.
  - Fail open if the root can’t be determined to preserve same-project guarding.
  - Added tests to ensure foreign-project plans are ignored and in-project plans still block.

<sup>Written for commit 94874e7f06db36f7fd369ff296bf184d9a6b4b1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/maxritter/pilot-shell/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

