### PR TITLE
fix(codex): avoid duplicate shell_environment_policy.set on env sync

### DIFF
--- a/pilot/hooks/codex_skill_sync.py
+++ b/pilot/hooks/codex_skill_sync.py
@@ -431,7 +431,7 @@ def _sync_codex_env_vars() -> int:
 
     env_lines = [f'{k} = "{v}"' for k, v in sorted(env_vars.items())]
     managed_block = (
-        f"\n{_ENV_MARKER_START}\n[shell_environment_policy.set]\n" + "\n".join(env_lines) + f"\n{_ENV_MARKER_END}\n"
+        f"\n{_ENV_MARKER_START}\n" + "\n".join(env_lines) + f"\n{_ENV_MARKER_END}\n"
     )
 
     try:
@@ -444,7 +444,10 @@ def _sync_codex_env_vars() -> int:
         end = existing.index(_ENV_MARKER_END) + len(_ENV_MARKER_END)
         new_content = existing[:start].rstrip("\n") + managed_block + existing[end:].lstrip("\n")
     else:
-        new_content = existing.rstrip("\n") + managed_block
+        block = managed_block
+        if "[shell_environment_policy.set]" not in existing:
+            block = "\n[shell_environment_policy.set]" + block
+        new_content = existing.rstrip("\n") + block
 
     if new_content != existing:
         tmp = codex_config.with_suffix(".toml.tmp")

--- a/pilot/hooks/tests/test_codex_skill_sync.py
+++ b/pilot/hooks/tests/test_codex_skill_sync.py
@@ -449,7 +449,7 @@ class TestSyncCodexEnvVars:
 
         assert count == 7
         content = codex_config.read_text()
-        assert "[shell_environment_policy.set]" in content
+        assert content.count("[shell_environment_policy.set]") == 1
         assert 'PILOT_PLAN_APPROVAL_ENABLED = "false"' in content
         assert 'PILOT_BRANCH_ISOLATION_ENABLED = "true"' in content
         # Automated model switching is Claude-Code-only -- Codex never gets the var.
@@ -480,8 +480,8 @@ class TestSyncCodexEnvVars:
         codex_config.parent.mkdir(parents=True)
         codex_config.write_text(
             'approval_policy = "never"\n'
-            "\n# --- pilot-shell managed env vars ---\n"
-            "[shell_environment_policy.set]\n"
+            "\n[shell_environment_policy.set]\n"
+            "# --- pilot-shell managed env vars ---\n"
             'PILOT_PLAN_APPROVAL_ENABLED = "false"\n'
             "# --- end pilot-shell managed env vars ---\n"
         )
@@ -490,8 +490,28 @@ class TestSyncCodexEnvVars:
             _sync_codex_env_vars()
 
         content = codex_config.read_text()
-        assert content.count("shell_environment_policy") == 1
+        assert content.count("[shell_environment_policy.set]") == 1
         assert 'PILOT_PLAN_APPROVAL_ENABLED = "true"' in content
+        tomllib.loads(content)
+
+    def test_does_not_duplicate_section_header_when_codex_config_already_has_one(
+        self, tmp_path: Path
+    ) -> None:
+        codex_config = tmp_path / ".codex" / "config.toml"
+        codex_config.parent.mkdir(parents=True)
+        codex_config.write_text(
+            'approval_policy = "never"\n'
+            "\n[shell_environment_policy.set]\n"
+            "SOME_EXISTING_VAR = \"1\"\n"
+        )
+
+        with patch("codex_skill_sync.Path.home", return_value=tmp_path):
+            _sync_codex_env_vars()
+
+        content = codex_config.read_text()
+        assert content.count("[shell_environment_policy.set]") == 1
+        assert "SOME_EXISTING_VAR" in content
+        tomllib.loads(content)
 
     def test_defaults_branch_isolation_to_true_when_config_missing(self, tmp_path: Path) -> None:
         """When config.json is absent, branchIsolation should default to true (matching Console)."""


### PR DESCRIPTION
## Summary

- Fixes Codex `config.toml` duplicate-key parse failures triggered by `codex_skill_sync.py` on every Codex SessionStart
- Root cause: the env-sync update path re-emits `[shell_environment_policy.set]` inside the pilot-managed block while the config already has that section header (typical for Codex users with `PATH`, API keys, or `[shell_environment_policy]` inherit settings)
- Managed block now contains only marker comments + `PILOT_*` lines; the section header is inserted on first write only when missing

## Impact

Not user-specific. Reproduced on upstream 9.4.0 with a realistic `~/.codex/config.toml` that already has `[shell_environment_policy]` + `[shell_environment_policy.set]`: **first SessionStart sync** produces two section headers and `tomllib` fails with duplicate key.

Fresh installs with no pre-existing env section are unaffected.

## Test plan

- [x] `uv run pytest pilot/hooks/tests/test_codex_skill_sync.py` — 45 passed
- [x] New test: pre-existing `[shell_environment_policy.set]` does not duplicate on sync
- [x] Updated `test_replaces_existing_managed_block` fixture: section header outside managed markers (realistic layout)
- [x] Manual repro: realistic Codex config → upstream breaks; fix keeps single header + valid TOML


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate `[shell_environment_policy.set]` in Codex `config.toml` during env sync, avoiding TOML parse failures and broken startup. Works with existing configs; fresh installs are unchanged.

- **Bug Fixes**
  - Keep the section header outside the pilot-managed block; managed block now only markers and `PILOT_*` lines.
  - Insert the section header only on first write if missing; no re-emission on sync.
  - Added a regression test for pre-existing headers and updated fixtures to ensure a single header and valid TOML.

<sup>Written for commit 875f62ed82dbcbaa574ff7590d569972c277d9c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/maxritter/pilot-shell/pull/162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

