### PR TITLE
fix(installer): handle TypeError and AttributeError during tree cache / tree.json retrieval

### DIFF
--- a/installer/downloads.py
+++ b/installer/downloads.py
@@ -279,7 +279,7 @@ def get_repo_files(dir_path: str, config: DownloadConfig) -> list[FileInfo]:
                             if path.startswith(dir_path):
                                 remote_files.append(FileInfo(path=path, sha=sha))
                 return remote_files
-    except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError, TimeoutError):
+    except (urllib.error.HTTPError, urllib.error.URLError, json.JSONDecodeError, TypeError, AttributeError, TimeoutError):
         pass
 
     try:
@@ -317,5 +317,6 @@ def get_repo_files(dir_path: str, config: DownloadConfig) -> list[FileInfo]:
         if e.code == 304 and cached_files:
             return _files_from_cache(cached_files, dir_path)
         return []
-    except (urllib.error.URLError, json.JSONDecodeError, TimeoutError):
+    except (urllib.error.URLError, json.JSONDecodeError, TypeError, AttributeError, TimeoutError):
         return []
+

--- a/installer/tests/unit/test_downloads.py
+++ b/installer/tests/unit/test_downloads.py
@@ -561,3 +561,47 @@ class TestTreeJsonFallback:
         assert len(files) == 1
         assert files[0].path == "pilot/test.py"
         assert files[0].sha == "xyz789"
+
+    def test_get_repo_files_falls_back_to_api_on_malformed_tree_json(self):
+        """get_repo_files falls back to API when tree.json has invalid structure (raises TypeError/AttributeError)."""
+        from unittest.mock import MagicMock, patch
+
+        from installer.downloads import DownloadConfig, get_repo_files
+
+        config = DownloadConfig(
+            repo_url="https://github.com/test/repo",
+            repo_branch="v6.0.0",
+        )
+
+        api_data = {
+            "tree": [
+                {"path": "pilot/test.py", "type": "blob", "sha": "xyz789"},
+            ]
+        }
+
+        # Return an int, causing "tree" in data to raise TypeError
+        malformed_data = 123
+
+
+        def side_effect(request, *_args, **_kwargs):
+            url = request.full_url if hasattr(request, "full_url") else str(request)
+            mock_response = MagicMock()
+            mock_response.status = 200
+            mock_response.headers.get.return_value = None
+            mock_response.__enter__.return_value = mock_response
+            mock_response.__exit__.return_value = None
+
+            if "tree.json" in url:
+                mock_response.read.return_value = json.dumps(malformed_data).encode()
+            else:
+                mock_response.read.return_value = json.dumps(api_data).encode()
+            return mock_response
+
+        with patch("urllib.request.urlopen", side_effect=side_effect) as mock_urlopen:
+            files = get_repo_files("pilot", config)
+
+        assert mock_urlopen.call_count == 2
+        assert len(files) == 1
+        assert files[0].path == "pilot/test.py"
+        assert files[0].sha == "xyz789"
+


### PR DESCRIPTION
Catches TypeError and AttributeError during tree JSON parsing in get_repo_files fallback mechanisms. This ensures that the installer falls back to alternative methods or returns cleanly if GitHub releases return non-dictionary payloads or malformed JSON structures, instead of raising unhandled exceptions and crashing the installer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent installer crashes when `tree.json` or tree cache responses are malformed by catching `TypeError` and `AttributeError`, and falling back to the API or returning safely. Adds a unit test to cover the malformed `tree.json` case.

- **Bug Fixes**
  - Catch `TypeError` and `AttributeError` in `installer.downloads.get_repo_files` for both tree cache and `tree.json` parsing paths.
  - Fallback to the GitHub API or return an empty list instead of raising unhandled exceptions.
  - Added a unit test to confirm fallback when `tree.json` returns an invalid structure.

<sup>Written for commit a070439250d6ce1b1351b57ba22f35b6f3da5428. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/maxritter/pilot-shell/pull/165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file discovery reliability when cached repository data is missing or malformed.
  * If repository tree data can’t be parsed or returned in an unexpected format, the app now safely falls back to the GitHub API or returns no files instead of failing.
  * Added test coverage for fallback behavior with malformed tree data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->